### PR TITLE
Add global search, smart-locks import/export, receipts export, and fi…

### DIFF
--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -31,6 +31,7 @@ from properties import properties_bp
 from audits import audits_bp
 from smartlocks import smartlocks_bp
 from exports import exports_bp
+from search import search_bp
 
 migrate_master = Migrate()
 migrate_tenant = Migrate()
@@ -94,6 +95,7 @@ def create_app():
     app.register_blueprint(smartlocks_bp, url_prefix="/smart-locks")
     app.register_blueprint(exports_bp, url_prefix="/exports")
     app.register_blueprint(audits_bp, url_prefix="/audits")
+    app.register_blueprint(search_bp)
 
     # 8) Debug helpers (DISABLED FOR SECURITY)
     # These routes are disabled for production security

--- a/exports/views.py
+++ b/exports/views.py
@@ -791,6 +791,31 @@ def download_import_template(item_type: str):
                     'Property Unit Label': ''
                 }
             ]
+        },
+        'smartlocks': {
+            'filename': 'smartlocks_import_template.csv',
+            'data': [
+                {
+                    'Label': 'Front Door — Sunset 101',
+                    'Code': '482931',
+                    'Provider': 'August',
+                    'Backup Code': '193847',
+                    'Instructions': 'Press # after entering code',
+                    'Notes': 'Battery replaced 2025-08-12',
+                    'Property Name': 'Sunset Apartments',
+                    'Property Unit Label': 'Apt 101',
+                },
+                {
+                    'Label': 'Garage — 456 Oak',
+                    'Code': '7421',
+                    'Provider': 'Schlage',
+                    'Backup Code': '',
+                    'Instructions': '',
+                    'Notes': '',
+                    'Property Name': 'Oak Street Complex',
+                    'Property Unit Label': '',
+                },
+            ]
         }
     }
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -2491,51 +2491,92 @@ def checkout_receipt(checkout_id):
     )
 
 
+def _receipt_search_query(query: str):
+    """Build the SQLAlchemy query for receipt search.
+
+    Searches across receipt id (RCP###### or numeric), the person checked out to,
+    the checkout address, and — via JOIN — the item label and custom_id. Returns
+    a query object the caller can paginate / count / .all() on.
+    """
+    from sqlalchemy import or_
+
+    base = tenant_query(ItemCheckout).outerjoin(Item, ItemCheckout.item_id == Item.id)
+
+    if not query:
+        return base.order_by(ItemCheckout.checked_out_at.desc())
+
+    receipt_id = None
+    candidate = query[3:] if query.upper().startswith("RCP") else query
+    try:
+        receipt_id = int(candidate)
+    except ValueError:
+        pass
+
+    like = f"%{query}%"
+    filters = [
+        ItemCheckout.checked_out_to.ilike(like),
+        ItemCheckout.address.ilike(like),
+        Item.label.ilike(like),
+        Item.custom_id.ilike(like),
+    ]
+    if receipt_id is not None:
+        filters.append(ItemCheckout.id == receipt_id)
+
+    return base.filter(or_(*filters)).order_by(ItemCheckout.checked_out_at.desc())
+
+
 @inventory_bp.route("/receipts", methods=["GET"])
 @login_required
 @tenant_required
 def receipt_lookup():
     """Receipt lookup page with barcode scanner support"""
     query = (request.args.get("q") or "").strip()
-    results = []
-    
+
     if query:
-        # Try to extract receipt ID from barcode (RCP000001 format)
-        receipt_id = None
-        if query.upper().startswith("RCP"):
-            try:
-                receipt_id = int(query[3:])
-            except ValueError:
-                pass
-        else:
-            # Try direct ID
-            try:
-                receipt_id = int(query)
-            except ValueError:
-                pass
-        
-        # Build search filter
-        filters = []
-        if receipt_id:
-            filters.append(ItemCheckout.id == receipt_id)
-        
-        # Also search by checked_out_to name
-        if query:
-            like = f"%{query}%"
-            filters.append(ItemCheckout.checked_out_to.ilike(like))
-        
-        if filters:
-            from sqlalchemy import or_
-            results = tenant_query(ItemCheckout).filter(or_(*filters)).order_by(
-                ItemCheckout.checked_out_at.desc()
-            ).limit(50).all()
+        results = _receipt_search_query(query).limit(50).all()
     else:
-        # Show 10 most recent receipts by default when no search query
-        results = tenant_query(ItemCheckout).order_by(
-            ItemCheckout.checked_out_at.desc()
-        ).limit(10).all()
-    
+        results = _receipt_search_query("").limit(10).all()
+
     return render_template("receipt_lookup.html", results=results, query=query)
+
+
+@inventory_bp.route("/receipts/export", methods=["GET"])
+@login_required
+@tenant_required
+def export_receipts():
+    """Export receipts (filtered by current search) as CSV or Excel."""
+    from exports.views import generate_csv, generate_excel
+    from datetime import datetime
+
+    query = (request.args.get("q") or "").strip()
+    format_type = (request.args.get("format") or "csv").lower()
+
+    # Cap the export at 10k rows so a runaway query can't OOM the worker.
+    rows = _receipt_search_query(query).limit(10000).all()
+
+    data = []
+    for c in rows:
+        item = c.item
+        data.append({
+            "Receipt #": c.id,
+            "Barcode": f"RCP{c.id:06d}",
+            "Item Label": item.label if item else "",
+            "Item Type": item.type if item else "",
+            "Item ID": (item.custom_id if item else "") or "",
+            "Checked Out To": c.checked_out_to or "",
+            "Quantity": c.quantity or 0,
+            "Address": c.address or "",
+            "Purpose": c.purpose or "",
+            "Assignment Type": c.assignment_type or "",
+            "Checked Out At": c.checked_out_at.strftime("%Y-%m-%d %H:%M:%S") if c.checked_out_at else "",
+            "Checked In At": c.checked_in_at.strftime("%Y-%m-%d %H:%M:%S") if c.checked_in_at else "",
+            "Status": "Returned" if not c.is_active else "Checked Out",
+        })
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    if format_type == "excel":
+        return generate_excel(data, f"receipts_{timestamp}.xlsx")
+    return generate_csv(data, f"receipts_{timestamp}.csv")
 
 @inventory_bp.route("/items/<int:item_id>", methods=["GET"])
 @login_required

--- a/search/__init__.py
+++ b/search/__init__.py
@@ -1,0 +1,3 @@
+from .views import search_bp
+
+__all__ = ["search_bp"]

--- a/search/views.py
+++ b/search/views.py
@@ -1,0 +1,285 @@
+# search/views.py
+"""Global cross-entity search.
+
+Two endpoints:
+  GET /search/suggest?q=...  -> JSON, top-N matches across types (autocomplete)
+  GET /search?q=...          -> HTML page, all matches grouped by type
+
+Search covers items (lockboxes/keys/signs), properties, contacts, smart locks,
+and receipts (item checkouts).
+"""
+from flask import Blueprint, jsonify, render_template, request, url_for
+from flask_login import login_required
+from sqlalchemy import or_
+
+from middleware.tenant_middleware import tenant_required
+from utilities.tenant_helpers import tenant_query
+from utilities.database import (
+    Item,
+    Property,
+    Contact,
+    SmartLock,
+    ItemCheckout,
+)
+
+search_bp = Blueprint("search", __name__, template_folder="../templates")
+
+
+# Per-type cap for the suggest dropdown — keeps the JSON payload small and the
+# UI scannable. The full search page uses larger caps.
+SUGGEST_PER_TYPE = 4
+SEARCH_PER_TYPE = 25
+
+
+def _item_type_kind(item: Item) -> str:
+    """Return the lowercase entity kind for an Item, used for icons & labels."""
+    t = (item.type or "").lower()
+    if t == "lockbox":
+        return "lockbox"
+    if t == "key":
+        return "key"
+    if t == "sign":
+        return "sign"
+    return "item"
+
+
+def _item_subtitle(item: Item) -> str:
+    parts = []
+    if item.custom_id:
+        parts.append(item.custom_id)
+    if item.address:
+        parts.append(item.address)
+    elif item.location:
+        parts.append(item.location)
+    if item.status:
+        parts.append(item.status)
+    return " · ".join(parts)
+
+
+def _search_items(like: str, limit: int):
+    return (
+        tenant_query(Item)
+        .filter(
+            or_(
+                Item.label.ilike(like),
+                Item.custom_id.ilike(like),
+                Item.address.ilike(like),
+                Item.location.ilike(like),
+                Item.key_hook_number.ilike(like),
+                Item.keycode.ilike(like),
+                Item.code_current.ilike(like),
+                Item.supra_id.ilike(like),
+                Item.assigned_to.ilike(like),
+            )
+        )
+        .order_by(Item.label.asc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _search_properties(like: str, limit: int):
+    return (
+        tenant_query(Property)
+        .filter(
+            or_(
+                Property.name.ilike(like),
+                Property.address_line1.ilike(like),
+                Property.address_line2.ilike(like),
+                Property.city.ilike(like),
+                Property.postal_code.ilike(like),
+            )
+        )
+        .order_by(Property.name.asc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _search_contacts(like: str, limit: int):
+    return (
+        tenant_query(Contact)
+        .filter(
+            or_(
+                Contact.name.ilike(like),
+                Contact.company.ilike(like),
+                Contact.email.ilike(like),
+                Contact.phone.ilike(like),
+            )
+        )
+        .order_by(Contact.name.asc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _search_smartlocks(like: str, limit: int):
+    return (
+        tenant_query(SmartLock)
+        .filter(
+            or_(
+                SmartLock.label.ilike(like),
+                SmartLock.code.ilike(like),
+                SmartLock.provider.ilike(like),
+            )
+        )
+        .order_by(SmartLock.label.asc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _search_receipts(query: str, like: str, limit: int):
+    """Receipts are ItemCheckout rows. Match on RCP## / id / who / item label."""
+    receipt_id = None
+    candidate = query[3:] if query.upper().startswith("RCP") else query
+    try:
+        receipt_id = int(candidate)
+    except ValueError:
+        pass
+
+    filters = [
+        ItemCheckout.checked_out_to.ilike(like),
+        ItemCheckout.address.ilike(like),
+        Item.label.ilike(like),
+        Item.custom_id.ilike(like),
+    ]
+    if receipt_id is not None:
+        filters.append(ItemCheckout.id == receipt_id)
+
+    return (
+        tenant_query(ItemCheckout)
+        .outerjoin(Item, ItemCheckout.item_id == Item.id)
+        .filter(or_(*filters))
+        .order_by(ItemCheckout.checked_out_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def _serialize_item(item: Item) -> dict:
+    kind = _item_type_kind(item)
+    return {
+        "type": kind,
+        "type_label": kind.capitalize(),
+        "label": item.label,
+        "subtitle": _item_subtitle(item),
+        "url": url_for("inventory.item_details", item_id=item.id),
+    }
+
+
+def _serialize_property(prop: Property) -> dict:
+    return {
+        "type": "property",
+        "type_label": "Property",
+        "label": prop.name,
+        "subtitle": prop.address_line1 or "",
+        "url": url_for("properties.property_detail", property_id=prop.id),
+    }
+
+
+def _serialize_contact(contact: Contact) -> dict:
+    subtitle_parts = []
+    if contact.company:
+        subtitle_parts.append(contact.company)
+    if contact.email:
+        subtitle_parts.append(contact.email)
+    elif contact.phone:
+        subtitle_parts.append(contact.phone)
+    return {
+        "type": "contact",
+        "type_label": "Contact",
+        "label": contact.name,
+        "subtitle": " · ".join(subtitle_parts),
+        "url": url_for("contacts.contact_detail", contact_id=contact.id),
+    }
+
+
+def _serialize_smartlock(lock: SmartLock) -> dict:
+    parts = []
+    if lock.provider:
+        parts.append(lock.provider)
+    if lock.property:
+        parts.append(lock.property.name)
+    return {
+        "type": "smartlock",
+        "type_label": "Smart Lock",
+        "label": lock.label,
+        "subtitle": " · ".join(parts),
+        "url": url_for("smartlocks.smartlock_detail", lock_id=lock.id),
+    }
+
+
+def _serialize_receipt(checkout: ItemCheckout) -> dict:
+    item_label = checkout.item.label if checkout.item else "Item not found"
+    return {
+        "type": "receipt",
+        "type_label": "Receipt",
+        "label": f"RCP{checkout.id:06d} — {item_label}",
+        "subtitle": f"To {checkout.checked_out_to}" if checkout.checked_out_to else "",
+        "url": url_for("inventory.checkout_receipt", checkout_id=checkout.id),
+    }
+
+
+@search_bp.get("/search/suggest")
+@login_required
+@tenant_required
+def suggest():
+    """Autocomplete endpoint — top-N matches across all types as flat JSON."""
+    q = (request.args.get("q") or "").strip()
+    if len(q) < 2:
+        return jsonify({"results": [], "query": q})
+
+    like = f"%{q}%"
+
+    results = []
+    results.extend(_serialize_item(i) for i in _search_items(like, SUGGEST_PER_TYPE))
+    results.extend(_serialize_property(p) for p in _search_properties(like, SUGGEST_PER_TYPE))
+    results.extend(_serialize_contact(c) for c in _search_contacts(like, SUGGEST_PER_TYPE))
+    results.extend(_serialize_smartlock(s) for s in _search_smartlocks(like, SUGGEST_PER_TYPE))
+    results.extend(_serialize_receipt(r) for r in _search_receipts(q, like, SUGGEST_PER_TYPE))
+
+    return jsonify({"results": results, "query": q})
+
+
+@search_bp.get("/search")
+@login_required
+@tenant_required
+def search():
+    """Full search page — sections per entity type."""
+    q = (request.args.get("q") or "").strip()
+
+    if not q:
+        return render_template("search_results.html", query=q, sections=[], total=0)
+
+    like = f"%{q}%"
+    sections = [
+        {
+            "title": "Inventory Items",
+            "kind": "item",
+            "results": [_serialize_item(i) for i in _search_items(like, SEARCH_PER_TYPE)],
+        },
+        {
+            "title": "Properties",
+            "kind": "property",
+            "results": [_serialize_property(p) for p in _search_properties(like, SEARCH_PER_TYPE)],
+        },
+        {
+            "title": "Contacts",
+            "kind": "contact",
+            "results": [_serialize_contact(c) for c in _search_contacts(like, SEARCH_PER_TYPE)],
+        },
+        {
+            "title": "Smart Locks",
+            "kind": "smartlock",
+            "results": [_serialize_smartlock(s) for s in _search_smartlocks(like, SEARCH_PER_TYPE)],
+        },
+        {
+            "title": "Receipts",
+            "kind": "receipt",
+            "results": [_serialize_receipt(r) for r in _search_receipts(q, like, SEARCH_PER_TYPE)],
+        },
+    ]
+    total = sum(len(s["results"]) for s in sections)
+
+    return render_template("search_results.html", query=q, sections=sections, total=total)

--- a/smartlocks/__init__.py
+++ b/smartlocks/__init__.py
@@ -1,3 +1,4 @@
 from .views import smartlocks_bp
+from . import import_views  # noqa: F401  (registers import routes)
 
 __all__ = ['smartlocks_bp']

--- a/smartlocks/import_views.py
+++ b/smartlocks/import_views.py
@@ -1,0 +1,204 @@
+# smartlocks/import_views.py
+"""Import functionality for smart locks. Mirrors inventory/import_views.py."""
+from flask import render_template, request, redirect, url_for, flash, session
+from flask_login import login_required
+from werkzeug.utils import secure_filename
+
+from utilities.tenant_helpers import tenant_query, tenant_add, tenant_commit, tenant_rollback
+from middleware.tenant_middleware import tenant_required
+from utilities.database import SmartLock, Property, PropertyUnit
+from inventory.import_views import allowed_file, parse_csv_file, parse_excel_file
+from . import smartlocks_bp
+
+
+SMARTLOCK_FIELDS = {
+    'label': {'required': True, 'name': 'Label'},
+    'code': {'required': True, 'name': 'Code'},
+    'provider': {'required': False, 'name': 'Provider'},
+    'backup_code': {'required': False, 'name': 'Backup Code'},
+    'instructions': {'required': False, 'name': 'Instructions'},
+    'notes': {'required': False, 'name': 'Notes'},
+    'property_name': {'required': False, 'name': 'Property Name'},
+    'property_unit_label': {'required': False, 'name': 'Property Unit Label'},
+}
+
+
+@smartlocks_bp.route("/import", methods=["GET", "POST"])
+@login_required
+@tenant_required
+def import_smartlocks():
+    """Upload step — accept a CSV/Excel and stash it in session for mapping."""
+    if request.method == "POST":
+        if 'file' not in request.files:
+            flash("No file uploaded", "error")
+            return redirect(request.url)
+
+        file = request.files['file']
+        if not file.filename:
+            flash("No file selected", "error")
+            return redirect(request.url)
+
+        if not allowed_file(file.filename):
+            flash("Invalid file type. Please upload a CSV or Excel file.", "error")
+            return redirect(request.url)
+
+        try:
+            filename = secure_filename(file.filename)
+            ext = filename.rsplit('.', 1)[1].lower()
+            if ext == 'csv':
+                headers, rows = parse_csv_file(file.read().decode('utf-8'))
+            else:
+                headers, rows = parse_excel_file(file.read())
+
+            if not headers or not rows:
+                flash("File is empty or could not be parsed", "error")
+                return redirect(request.url)
+
+            session['import_data'] = {
+                'headers': headers,
+                'rows': rows[:1000],
+                'total_rows': len(rows),
+                'file_type': 'smartlocks',
+            }
+            return redirect(url_for('smartlocks.import_smartlocks_map'))
+        except Exception as e:
+            flash(f"Error processing file: {str(e)}", "error")
+            return redirect(request.url)
+
+    return render_template(
+        "import_upload.html",
+        item_type="SmartLocks",
+        restart_url=url_for('smartlocks.import_smartlocks'),
+        cancel_url=url_for('smartlocks.list_smartlocks'),
+    )
+
+
+@smartlocks_bp.route("/import/map", methods=["GET", "POST"])
+@login_required
+@tenant_required
+def import_smartlocks_map():
+    """Map uploaded columns to SmartLock fields."""
+    import_data = session.get('import_data')
+    if not import_data or import_data.get('file_type') != 'smartlocks':
+        flash("No import data found. Please upload a file first.", "error")
+        return redirect(url_for('smartlocks.import_smartlocks'))
+
+    if request.method == "POST":
+        mapping = {}
+        for field_name in SMARTLOCK_FIELDS:
+            column = request.form.get(f'map_{field_name}')
+            if column:
+                mapping[field_name] = column
+
+        for field_name, config in SMARTLOCK_FIELDS.items():
+            if config['required'] and field_name not in mapping:
+                flash(f"Please map the required field: {config['name']}", "error")
+                return redirect(request.url)
+
+        session['import_mapping'] = mapping
+        return redirect(url_for('smartlocks.import_smartlocks_process'))
+
+    return render_template(
+        "import_map.html",
+        import_data=import_data,
+        fields=SMARTLOCK_FIELDS,
+        item_type="SmartLocks",
+        restart_url=url_for('smartlocks.import_smartlocks'),
+    )
+
+
+@smartlocks_bp.route("/import/process", methods=["GET", "POST"])
+@login_required
+@tenant_required
+def import_smartlocks_process():
+    """Preview, then commit, the mapped smart-lock import."""
+    import_data = session.get('import_data')
+    mapping = session.get('import_mapping')
+
+    if not import_data or not mapping or import_data.get('file_type') != 'smartlocks':
+        flash("Import session expired. Please start over.", "error")
+        return redirect(url_for('smartlocks.import_smartlocks'))
+
+    if request.method == "POST":
+        rows = import_data['rows']
+        created_count = 0
+        error_count = 0
+        errors = []
+
+        for idx, row in enumerate(rows, 1):
+            try:
+                label = (row.get(mapping.get('label', '')) or '').strip()
+                code = (row.get(mapping.get('code', '')) or '').strip()
+                if not label:
+                    error_count += 1
+                    errors.append(f"Row {idx}: Label is required")
+                    continue
+                if not code:
+                    error_count += 1
+                    errors.append(f"Row {idx}: Code is required")
+                    continue
+
+                lock_data = {'label': label, 'code': code}
+                for field_name in ('provider', 'backup_code', 'instructions', 'notes'):
+                    column = mapping.get(field_name)
+                    if column:
+                        value = (row.get(column) or '').strip()
+                        if value:
+                            lock_data[field_name] = value
+
+                property_obj = None
+                property_unit_obj = None
+                property_name = (row.get(mapping.get('property_name', '')) or '').strip()
+                property_unit_label = (row.get(mapping.get('property_unit_label', '')) or '').strip()
+
+                if property_name:
+                    property_obj = tenant_query(Property).filter(
+                        Property.name.ilike(property_name)
+                    ).first()
+
+                if property_obj and property_unit_label:
+                    property_unit_obj = tenant_query(PropertyUnit).filter(
+                        PropertyUnit.property_id == property_obj.id,
+                        PropertyUnit.label.ilike(property_unit_label),
+                    ).first()
+
+                lock = SmartLock(
+                    property_id=property_obj.id if property_obj else None,
+                    property_unit_id=property_unit_obj.id if property_unit_obj else None,
+                    **lock_data,
+                )
+                tenant_add(lock)
+                created_count += 1
+            except Exception as e:
+                error_count += 1
+                errors.append(f"Row {idx}: {str(e)}")
+
+        try:
+            tenant_commit()
+            flash(f"Successfully imported {created_count} smart locks.", "success")
+            if error_count:
+                flash(f"{error_count} rows had errors.", "warning")
+            session.pop('import_data', None)
+            session.pop('import_mapping', None)
+            return redirect(url_for('smartlocks.list_smartlocks'))
+        except Exception as e:
+            tenant_rollback()
+            flash(f"Database error: {str(e)}", "error")
+            return redirect(url_for('smartlocks.import_smartlocks'))
+
+    preview_rows = import_data['rows'][:10]
+    preview_data = []
+    for row in preview_rows:
+        preview_item = {field: row.get(column, '') for field, column in mapping.items()}
+        preview_data.append(preview_item)
+
+    return render_template(
+        "import_preview.html",
+        preview_data=preview_data,
+        total_rows=import_data['total_rows'],
+        fields=SMARTLOCK_FIELDS,
+        mapping=mapping,
+        item_type="SmartLocks",
+        restart_url=url_for('smartlocks.import_smartlocks'),
+        back_url=url_for('smartlocks.import_smartlocks_map'),
+    )

--- a/smartlocks/views.py
+++ b/smartlocks/views.py
@@ -119,3 +119,45 @@ def smartlock_detail(lock_id: int):
     smart_lock = _get_smartlock_or_404(lock_id)
     return render_template("smartlock_detail.html", smartlock=smart_lock)
 
+
+@smartlocks_bp.route("/export", methods=["GET"])
+@login_required
+@tenant_required
+def export_smartlocks():
+    """Export smart locks (filtered by current search) as CSV or Excel."""
+    from exports.views import generate_csv, generate_excel
+    from datetime import datetime
+
+    q = (request.args.get("q") or "").strip()
+    format_type = (request.args.get("format") or "csv").lower()
+
+    query = tenant_query(SmartLock)
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            or_(
+                SmartLock.label.ilike(like),
+                SmartLock.code.ilike(like),
+                SmartLock.provider.ilike(like),
+            )
+        )
+    locks = query.order_by(SmartLock.label.asc()).all()
+
+    data = []
+    for lock in locks:
+        data.append({
+            "Label": lock.label or "",
+            "Code": lock.code or "",
+            "Provider": lock.provider or "",
+            "Backup Code": lock.backup_code or "",
+            "Instructions": lock.instructions or "",
+            "Notes": lock.notes or "",
+            "Property": lock.property.name if lock.property else "",
+            "Unit": lock.property_unit.label if lock.property_unit else "",
+        })
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    if format_type == "excel":
+        return generate_excel(data, f"smartlocks_{timestamp}.xlsx")
+    return generate_csv(data, f"smartlocks_{timestamp}.csv")
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -243,6 +243,146 @@
         gap: 12px;
       }
 
+      /* Global search */
+      .global-search {
+        position: relative;
+        width: 320px;
+        max-width: 40vw;
+      }
+
+      .global-search-input {
+        width: 100%;
+        padding: 9px 12px 9px 34px;
+        border-radius: 10px;
+        border: 1px solid var(--color-border);
+        background: rgba(148, 163, 184, 0.08);
+        color: var(--color-text);
+        font-size: 14px;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .global-search-input::placeholder {
+        color: var(--color-muted);
+      }
+
+      .global-search-input:focus {
+        outline: none;
+        border-color: rgba(229, 57, 53, 0.45);
+        box-shadow: 0 0 0 3px var(--color-accent-soft);
+      }
+
+      .global-search-icon {
+        position: absolute;
+        left: 11px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--color-muted);
+        font-size: 14px;
+        pointer-events: none;
+      }
+
+      .global-search-dropdown {
+        display: none;
+        position: absolute;
+        top: calc(100% + 6px);
+        left: 0;
+        right: 0;
+        max-height: 480px;
+        overflow-y: auto;
+        background: var(--color-card);
+        border: 1px solid var(--color-border);
+        border-radius: 12px;
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+        z-index: 50;
+      }
+
+      .global-search.is-open .global-search-dropdown {
+        display: block;
+      }
+
+      .global-search-item {
+        display: grid;
+        grid-template-columns: 28px 1fr;
+        gap: 10px;
+        align-items: center;
+        padding: 10px 12px;
+        text-decoration: none;
+        color: var(--color-text);
+        cursor: pointer;
+        border-bottom: 1px solid var(--color-border);
+        transition: background 0.15s ease;
+      }
+
+      .global-search-item:last-of-type {
+        border-bottom: none;
+      }
+
+      .global-search-item:hover,
+      .global-search-item.is-active {
+        background: var(--color-accent-soft);
+      }
+
+      .global-search-icon-cell {
+        font-size: 18px;
+        text-align: center;
+      }
+
+      .global-search-text {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+      }
+
+      .global-search-label {
+        font-size: 14px;
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .global-search-subtitle {
+        font-size: 12px;
+        color: var(--color-muted);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .global-search-type {
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-muted);
+        margin-left: 4px;
+      }
+
+      .global-search-empty,
+      .global-search-loading {
+        padding: 14px 12px;
+        font-size: 13px;
+        color: var(--color-muted);
+        text-align: center;
+      }
+
+      .global-search-footer {
+        padding: 10px 12px;
+        font-size: 13px;
+        color: var(--color-accent);
+        border-top: 1px solid var(--color-border);
+        text-align: center;
+        cursor: pointer;
+      }
+
+      .global-search-footer:hover {
+        background: var(--color-accent-soft);
+      }
+
+      @media (max-width: 720px) {
+        .global-search { width: 180px; }
+      }
+
       .btn {
         display: inline-flex;
         align-items: center;
@@ -872,7 +1012,21 @@
         <header class="topbar">
           <button class="sidebar-toggle" type="button" data-sidebar-toggle aria-label="Toggle menu">☰</button>
           <div class="topbar-actions">
-            {% if current_user.is_authenticated %}
+            {% if current_user.is_authenticated and not is_root_domain %}
+              <form class="global-search" id="global-search" role="search"
+                    action="{{ url_for('search.search') }}" method="get" autocomplete="off">
+                <span class="global-search-icon">🔍</span>
+                <input
+                  type="search"
+                  name="q"
+                  class="global-search-input"
+                  placeholder="Search keys, lockboxes, properties, contacts…"
+                  aria-label="Global search"
+                  autocomplete="off">
+                <div class="global-search-dropdown" role="listbox" aria-label="Search suggestions"></div>
+              </form>
+              <span class="muted text-small">{{ current_user.email }}</span>
+            {% elif current_user.is_authenticated %}
               <span class="muted text-small">{{ current_user.email }}</span>
             {% endif %}
           </div>
@@ -975,6 +1129,136 @@
           showReceiptModal(receiptIdParam);
         }
       });
+
+      // ---- Global search autocomplete ----
+      (function () {
+        const form = document.getElementById('global-search');
+        if (!form) return;
+        const input = form.querySelector('.global-search-input');
+        const dropdown = form.querySelector('.global-search-dropdown');
+        const searchUrl = form.getAttribute('action');
+
+        const ICONS = {
+          lockbox: '🔒', key: '🔑', sign: '🪧', item: '📦',
+          property: '🏘️', contact: '👤', smartlock: '🔐', receipt: '🧾'
+        };
+
+        let debounceTimer = null;
+        let activeFetch = null;
+        let activeIndex = -1;
+        let currentResults = [];
+
+        function open() { form.classList.add('is-open'); }
+        function close() {
+          form.classList.remove('is-open');
+          activeIndex = -1;
+        }
+        function escapeHtml(s) {
+          return String(s).replace(/[&<>"']/g, function (c) {
+            return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+          });
+        }
+
+        function renderResults(results, query) {
+          currentResults = results;
+          activeIndex = -1;
+          if (!query) { close(); return; }
+
+          const fullSearchUrl = searchUrl + '?q=' + encodeURIComponent(query);
+
+          if (results.length === 0) {
+            dropdown.innerHTML =
+              '<div class="global-search-empty">No matches for "' + escapeHtml(query) + '"</div>' +
+              '<a href="' + escapeHtml(fullSearchUrl) + '" class="global-search-footer">Search anyway</a>';
+            open();
+            return;
+          }
+
+          let html = '';
+          results.forEach(function (r, i) {
+            const icon = ICONS[r.type] || '•';
+            html +=
+              '<a href="' + escapeHtml(r.url) + '" class="global-search-item" data-idx="' + i + '">' +
+                '<span class="global-search-icon-cell">' + icon + '</span>' +
+                '<span class="global-search-text">' +
+                  '<span class="global-search-label">' + escapeHtml(r.label || '') +
+                    '<span class="global-search-type">' + escapeHtml(r.type_label || '') + '</span>' +
+                  '</span>' +
+                  (r.subtitle ? '<span class="global-search-subtitle">' + escapeHtml(r.subtitle) + '</span>' : '') +
+                '</span>' +
+              '</a>';
+          });
+          html += '<a href="' + escapeHtml(fullSearchUrl) + '" class="global-search-footer">' +
+                  'View all results for "' + escapeHtml(query) + '"</a>';
+          dropdown.innerHTML = html;
+          open();
+        }
+
+        function fetchSuggestions(query) {
+          if (activeFetch && activeFetch.abort) {
+            activeFetch.abort();
+          }
+          const controller = new AbortController();
+          activeFetch = controller;
+          dropdown.innerHTML = '<div class="global-search-loading">Searching…</div>';
+          open();
+          fetch('/search/suggest?q=' + encodeURIComponent(query), { signal: controller.signal })
+            .then(function (resp) { return resp.json(); })
+            .then(function (data) { renderResults(data.results || [], data.query || query); })
+            .catch(function (err) {
+              if (err.name === 'AbortError') return;
+              dropdown.innerHTML = '<div class="global-search-empty">Search failed.</div>';
+            });
+        }
+
+        input.addEventListener('input', function () {
+          const q = input.value.trim();
+          if (debounceTimer) clearTimeout(debounceTimer);
+          if (q.length < 2) { close(); return; }
+          debounceTimer = setTimeout(function () { fetchSuggestions(q); }, 180);
+        });
+
+        input.addEventListener('focus', function () {
+          if (input.value.trim().length >= 2 && currentResults.length) open();
+        });
+
+        input.addEventListener('keydown', function (e) {
+          const items = dropdown.querySelectorAll('.global-search-item');
+          if (e.key === 'ArrowDown') {
+            if (!form.classList.contains('is-open')) return;
+            e.preventDefault();
+            if (items.length === 0) return;
+            activeIndex = (activeIndex + 1) % items.length;
+            updateActive(items);
+          } else if (e.key === 'ArrowUp') {
+            if (!form.classList.contains('is-open')) return;
+            e.preventDefault();
+            if (items.length === 0) return;
+            activeIndex = (activeIndex - 1 + items.length) % items.length;
+            updateActive(items);
+          } else if (e.key === 'Enter') {
+            if (activeIndex >= 0 && items[activeIndex]) {
+              e.preventDefault();
+              window.location.href = items[activeIndex].getAttribute('href');
+            }
+            // Otherwise: let the form submit to /search?q=...
+          } else if (e.key === 'Escape') {
+            close();
+            input.blur();
+          }
+        });
+
+        function updateActive(items) {
+          items.forEach(function (el, i) {
+            el.classList.toggle('is-active', i === activeIndex);
+            if (i === activeIndex) el.scrollIntoView({ block: 'nearest' });
+          });
+        }
+
+        document.addEventListener('click', function (e) {
+          if (!form.contains(e.target)) close();
+        });
+      })();
     </script>
   </body>
 </html>

--- a/templates/import_map.html
+++ b/templates/import_map.html
@@ -99,7 +99,7 @@
 
       <div class="toolbar spaced">
         <button type="submit" class="btn primary">Continue to Preview</button>
-        <a class="btn ghost" href="{{ url_for('inventory.import_keys') }}">Start Over</a>
+        <a class="btn ghost" href="{{ restart_url or url_for('inventory.import_keys') }}">Start Over</a>
       </div>
     </form>
   </div>

--- a/templates/import_preview.html
+++ b/templates/import_preview.html
@@ -63,8 +63,8 @@
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <div class="toolbar spaced">
         <button type="submit" class="btn primary">Import Now ({{ total_rows }} rows)</button>
-        <a class="btn ghost" href="{{ url_for('inventory.import_keys_map') }}">Back to Mapping</a>
-        <a class="btn ghost" href="{{ url_for('inventory.import_keys') }}">Start Over</a>
+        <a class="btn ghost" href="{{ back_url or url_for('inventory.import_keys_map') }}">Back to Mapping</a>
+        <a class="btn ghost" href="{{ restart_url or url_for('inventory.import_keys') }}">Start Over</a>
       </div>
     </form>
   </div>

--- a/templates/import_upload.html
+++ b/templates/import_upload.html
@@ -23,6 +23,9 @@
           <li>Optional fields: Current Code, Previous Code, Supra ID, Location, Address, Status, Assigned To, Property Name, Property Unit Label</li>
           {% elif item_type == 'Signs' %}
           <li>Optional fields: Sign Type, Piece Type, Rider Text, Material, Condition, Storage Location, Property Address, Status, Assigned To, Property Name, Property Unit Label</li>
+          {% elif item_type == 'SmartLocks' %}
+          <li>Required fields: <strong>Label</strong>, <strong>Code</strong></li>
+          <li>Optional fields: Provider, Backup Code, Instructions, Notes, Property Name, Property Unit Label</li>
           {% endif %}
         </ul>
 
@@ -40,6 +43,10 @@ LB-002,5678,S-67890,456 Oak Ave</pre>
           <pre style="background: var(--color-card); border: 1px solid var(--color-border); padding: 10px; border-radius: 4px; overflow-x: auto; color: var(--color-text);">Label,Sign Type,Piece Type,Material,Condition
 For Sale Sign #1,Assembled Unit,Sign,Aluminum,Excellent
 Rider Piece #1,Piece,Name Rider,Metal,Good</pre>
+          {% elif item_type == 'SmartLocks' %}
+          <pre style="background: var(--color-card); border: 1px solid var(--color-border); padding: 10px; border-radius: 4px; overflow-x: auto; color: var(--color-text);">Label,Code,Provider,Property Name,Property Unit Label
+Front Door — 101,482931,August,Sunset Apartments,Apt 101
+Garage — 456 Oak,7421,Schlage,Oak Street Complex,</pre>
           {% endif %}
         </div>
 
@@ -58,6 +65,10 @@ Rider Piece #1,Piece,Name Rider,Metal,Good</pre>
           <a href="{{ url_for('exports.download_import_template', item_type='signs') }}" class="btn small primary" download>
             Download Signs Template
           </a>
+          {% elif item_type == 'SmartLocks' %}
+          <a href="{{ url_for('exports.download_import_template', item_type='smartlocks') }}" class="btn small primary" download>
+            Download Smart Locks Template
+          </a>
           {% endif %}
         </div>
       </div>
@@ -70,7 +81,9 @@ Rider Piece #1,Piece,Name Rider,Metal,Good</pre>
 
       <div class="toolbar spaced">
         <button type="submit" class="btn primary">Upload & Continue</button>
-        {% if item_type == 'Keys' %}
+        {% if cancel_url %}
+        <a class="btn ghost" href="{{ cancel_url }}">Cancel</a>
+        {% elif item_type == 'Keys' %}
         <a class="btn ghost" href="{{ url_for('inventory.list_keys') }}">Cancel</a>
         {% elif item_type == 'Lockboxes' %}
         <a class="btn ghost" href="{{ url_for('inventory.list_lockboxes') }}">Cancel</a>

--- a/templates/receipt_lookup.html
+++ b/templates/receipt_lookup.html
@@ -5,6 +5,8 @@
 <div class="page-header">
   <h1>Receipt Lookup</h1>
   <div class="toolbar">
+    <a href="{{ url_for('inventory.export_receipts', q=query, format='csv') }}" class="btn ghost">Export CSV</a>
+    <a href="{{ url_for('inventory.export_receipts', q=query, format='excel') }}" class="btn ghost">Export Excel</a>
     <a href="{{ url_for('main.home') }}" class="btn ghost">Back to Home</a>
   </div>
 </div>
@@ -12,7 +14,7 @@
 <div class="card" style="margin-bottom: 24px;">
   <h3>Search Receipts</h3>
   <p class="muted" style="margin-bottom: 16px;">
-    Search by receipt number, barcode (RCP######), or person's name.
+    Search by receipt number, barcode (RCP######), person's name, item label, item ID, or address.
     Barcode scanners are automatically detected.
   </p>
 

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+{% block title %}Search{% if query %} — {{ query }}{% endif %} - KBM{% endblock %}
+
+{% block head %}
+<style>
+  .search-results-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .search-section h2 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 12px;
+    color: var(--color-text);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .search-section-count {
+    font-size: 12px;
+    color: var(--color-muted);
+    font-weight: 500;
+    background: rgba(148, 163, 184, 0.12);
+    padding: 2px 8px;
+    border-radius: 999px;
+  }
+
+  .search-result-item {
+    display: grid;
+    grid-template-columns: 32px 1fr;
+    gap: 12px;
+    align-items: center;
+    padding: 10px 12px;
+    border-radius: 10px;
+    color: var(--color-text);
+    text-decoration: none;
+    transition: background 0.15s ease;
+  }
+
+  .search-result-item:hover {
+    background: var(--color-accent-soft);
+  }
+
+  .search-result-icon {
+    font-size: 20px;
+    text-align: center;
+  }
+
+  .search-result-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .search-result-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .search-result-subtitle {
+    font-size: 12px;
+    color: var(--color-muted);
+  }
+
+  .search-empty {
+    padding: 60px 20px;
+    text-align: center;
+    color: var(--color-muted);
+  }
+
+  .search-summary {
+    font-size: 14px;
+    color: var(--color-muted);
+    margin-bottom: 18px;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Search</h1>
+</div>
+
+<div class="card" style="margin-bottom: 20px;">
+  <form method="get" action="{{ url_for('search.search') }}" class="searchbar" style="width: 100%;">
+    <input type="text" name="q" value="{{ query or '' }}" placeholder="Search keys, lockboxes, properties, contacts, smart locks, receipts…" style="flex: 1;" autofocus>
+    <button class="btn primary small" type="submit">Search</button>
+    {% if query %}<a class="btn small" href="{{ url_for('search.search') }}">Clear</a>{% endif %}
+  </form>
+</div>
+
+{% if not query %}
+  <div class="search-empty">
+    <p>Type something above to search across the whole tenant.</p>
+    <p class="text-small">Inventory items · Properties · Contacts · Smart Locks · Receipts</p>
+  </div>
+{% elif total == 0 %}
+  <div class="search-empty">
+    <p>No matches for <strong>{{ query }}</strong>.</p>
+    <p class="text-small">Try a shorter or different term, or check spelling.</p>
+  </div>
+{% else %}
+  {% set icons = {'lockbox':'🔒','key':'🔑','sign':'🪧','item':'📦','property':'🏘️','contact':'👤','smartlock':'🔐','receipt':'🧾'} %}
+  <p class="search-summary">{{ total }} match{{ '' if total == 1 else 'es' }} for <strong>{{ query }}</strong></p>
+
+  <div class="search-results-grid">
+    {% for section in sections %}
+      {% if section.results %}
+      <div class="card search-section">
+        <h2>
+          {{ section.title }}
+          <span class="search-section-count">{{ section.results|length }}</span>
+        </h2>
+        {% for r in section.results %}
+        <a href="{{ r.url }}" class="search-result-item">
+          <span class="search-result-icon">{{ icons.get(r.type, '•') }}</span>
+          <span class="search-result-text">
+            <span class="search-result-label">{{ r.label }}</span>
+            {% if r.subtitle %}<span class="search-result-subtitle">{{ r.subtitle }}</span>{% endif %}
+          </span>
+        </a>
+        {% endfor %}
+      </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}
+{% endblock %}

--- a/templates/smartlocks.html
+++ b/templates/smartlocks.html
@@ -12,6 +12,9 @@
         <a class="btn small" href="{{ url_for('smartlocks.list_smartlocks') }}">Clear</a>
       {% endif %}
     </form>
+    <a class="btn ghost" href="{{ url_for('smartlocks.import_smartlocks') }}">Import</a>
+    <a class="btn ghost" href="{{ url_for('smartlocks.export_smartlocks', q=q, format='csv') }}">Export CSV</a>
+    <a class="btn ghost" href="{{ url_for('smartlocks.export_smartlocks', q=q, format='excel') }}">Export Excel</a>
     <a class="btn primary" href="{{ url_for('smartlocks.create_smartlock') }}">Add Smart Lock</a>
   </div>
 </div>


### PR DESCRIPTION
…x receipts search

Receipts search was missing JOINs against Item, so checking out an item then searching for it by label or item ID returned nothing. Now searches receipt id, name, address, item label, and item custom_id.

Receipts export: new /inventory/receipts/export route honors the current search filter, supports CSV and Excel.

Smart locks import/export:
- New smartlocks/import_views.py mirrors the inventory import flow (upload, map columns, preview, commit) using shared helpers.
- New /smartlocks/export route for CSV/Excel.
- Smart-locks template card added to the import-template downloader.
- Shared import templates take optional restart_url / cancel_url / back_url context vars so blueprints other than inventory land on the right pages.

Global search:
- New search/ blueprint with /search/suggest (JSON, autocomplete) and /search (HTML, full results page) covering items, properties, contacts, smart locks, and receipts.
- Topbar search input with Steam-style live dropdown, debounced fetch, keyboard nav (arrow keys / Enter / Escape), click-outside-to-close.
- Pressing Enter without selecting a suggestion submits to the full results page.