### PR TITLE
Stop spam signups + make cleanup feasible

### DIFF
--- a/accounts/routes.py
+++ b/accounts/routes.py
@@ -2,23 +2,49 @@
 Account signup and management routes.
 """
 
+import logging
+import re
+
 from flask import render_template, request, redirect, url_for, flash, current_app
 from . import accounts_bp
+from utilities.extensions import limiter
 from utilities.master_database import master_db, Account, MasterUser
 from utilities.tenant_manager import tenant_manager
 from middleware.tenant_middleware import root_domain_only
-import re
+
+log = logging.getLogger(__name__)
 
 
 @accounts_bp.route('/signup', methods=['GET', 'POST'])
 @root_domain_only
+@limiter.limit("3 per hour; 10 per day", methods=["POST"])
 def signup():
     """
     Company account signup form.
     Creates a new account, database, and first admin user.
+
+    New accounts land as status='pending' and require app-admin approval
+    before they can be used. This means even if a bot squeaks past the
+    honeypot + rate limit, the resulting account is unusable until a
+    human approves it.
     """
     if request.method == 'GET':
         return render_template('accounts/signup.html')
+
+    # ------------------------------------------------------------------
+    # Bot prevention layer 1: honeypot.
+    # The signup form has a hidden 'website' field that's invisible to
+    # humans (CSS-hidden). Bots that auto-fill every input will populate
+    # it. If we see a value, drop the request and pretend it succeeded
+    # so the bot doesn't retry.
+    # ------------------------------------------------------------------
+    if request.form.get('website', '').strip():
+        log.info("signup blocked by honeypot from %s", request.remote_addr)
+        flash('Account created. Awaiting administrator approval.', 'success')
+        return redirect(url_for('accounts.signup'))
+
+    # Bot prevention layer 2 — rate limit — is applied via the
+    # @limiter.limit decorator on this route (3/hour, 10/day per IP).
 
     # Process signup form
     subdomain = request.form.get('subdomain', '').lower().strip()
@@ -70,11 +96,14 @@ def signup():
                              admin_email=admin_email)
 
     try:
-        # Create account
+        # New accounts land as pending — an app admin must approve before
+        # the subdomain becomes usable. Until then, the tenant middleware
+        # blocks logins (returns 403) and the account shows up in the
+        # "Pending Approval" filter on the admin dashboard.
         account = Account(
             subdomain=subdomain,
             company_name=company_name,
-            status='active'
+            status='pending'
         )
 
         # Get database path
@@ -99,14 +128,14 @@ def signup():
         master_db.session.add(admin_user)
         master_db.session.commit()
 
-        flash(f'Account created successfully! Welcome to {company_name}!', 'success')
-
-        # Redirect to tenant subdomain
-        base_domain = current_app.config.get('BASE_DOMAIN', 'localhost:5000')
-        protocol = 'http' if 'localhost' in base_domain else 'https'
-        redirect_url = f"{protocol}://{subdomain}.{base_domain}/"
-
-        return redirect(redirect_url)
+        # Don't redirect to the subdomain — the account isn't active yet.
+        # Show a confirmation page so the user knows what to expect.
+        return render_template(
+            'accounts/signup_pending.html',
+            company_name=company_name,
+            subdomain=subdomain,
+            admin_email=admin_email,
+        )
 
     except Exception as e:
         master_db.session.rollback()

--- a/app_admin/routes.py
+++ b/app_admin/routes.py
@@ -145,43 +145,100 @@ def update_account_name(account_id):
     flash(f'Company name updated from "{old_name}" to "{new_name}"', 'success')
     return redirect(url_for('app_admin.view_account', account_id=account_id))
 
+def _purge_account(account: Account) -> tuple[bool, str]:
+    """Permanently delete an account, its tenant DB file, and its users.
+
+    Returns (success, message). Used by both single and bulk delete paths so
+    they share the exact same teardown logic.
+    """
+    subdomain = account.subdomain
+    company_name = account.company_name
+    try:
+        # Drop the tenant DB file (no-op if it's already gone).
+        tenant_manager.delete_tenant_database(account)
+        # Cascade on Account.users handles MasterUser deletion automatically.
+        # Cascade on Account.invitations handles invitations.
+        master_db.session.delete(account)
+        master_db.session.commit()
+        return True, f'Deleted "{company_name}" ({subdomain})'
+    except Exception as e:
+        master_db.session.rollback()
+        return False, f'Failed to delete "{company_name}" ({subdomain}): {e}'
+
+
 @app_admin_bp.route('/admin/accounts/<int:account_id>/delete', methods=['POST'])
 @login_required
 @app_admin_required
 @root_domain_only
 def delete_account(account_id):
-    """
-    Permanently delete an account and its database (use with extreme caution!).
+    """Permanently delete an account and its database.
+
+    The Danger-Zone form on the account detail page makes the operator type
+    the subdomain to confirm. The list-page Delete button skips that and
+    submits with `confirmed=quick`, since spam cleanup needs to be fast.
     """
     account = Account.query.get_or_404(account_id)
+    quick_confirm = request.form.get('confirmed') == 'quick'
 
-    # Require confirmation
-    confirmation = request.form.get('confirmation', '').strip()
-    if confirmation != account.subdomain:
-        flash('Incorrect confirmation. Account not deleted.', 'error')
-        return redirect(url_for('app_admin.view_account', account_id=account_id))
+    if not quick_confirm:
+        confirmation = request.form.get('confirmation', '').strip()
+        if confirmation != account.subdomain:
+            flash('Incorrect confirmation. Account not deleted.', 'error')
+            return redirect(url_for('app_admin.view_account', account_id=account_id))
 
-    subdomain = account.subdomain
-    company_name = account.company_name
+    ok, message = _purge_account(account)
+    flash(message, 'success' if ok else 'error')
+    return redirect(url_for('app_admin.list_accounts'))
 
+
+@app_admin_bp.route('/admin/accounts/bulk-delete', methods=['POST'])
+@login_required
+@app_admin_required
+@root_domain_only
+def bulk_delete_accounts():
+    """Delete several accounts at once. Used for clearing spam signups."""
+    raw_ids = request.form.getlist('account_ids')
     try:
-        # Delete tenant database file
-        tenant_manager.delete_tenant_database(account)
+        ids = [int(x) for x in raw_ids if str(x).strip().isdigit()]
+    except ValueError:
+        ids = []
 
-        # Delete all users in this account
-        MasterUser.query.filter_by(account_id=account.id).delete()
-
-        # Delete account record
-        master_db.session.delete(account)
-        master_db.session.commit()
-
-        flash(f'Account "{company_name}" ({subdomain}) has been permanently deleted.', 'success')
+    if not ids:
+        flash('No accounts selected.', 'error')
         return redirect(url_for('app_admin.list_accounts'))
 
-    except Exception as e:
-        master_db.session.rollback()
-        flash(f'Error deleting account: {str(e)}', 'error')
-        return redirect(url_for('app_admin.view_account', account_id=account_id))
+    accounts = Account.query.filter(Account.id.in_(ids)).all()
+
+    deleted = 0
+    failed = 0
+    for account in accounts:
+        ok, _msg = _purge_account(account)
+        if ok:
+            deleted += 1
+        else:
+            failed += 1
+
+    if deleted:
+        flash(f'Deleted {deleted} account{"" if deleted == 1 else "s"}.', 'success')
+    if failed:
+        flash(f'{failed} deletion{"" if failed == 1 else "s"} failed (see logs).', 'error')
+    return redirect(url_for('app_admin.list_accounts'))
+
+
+@app_admin_bp.route('/admin/accounts/<int:account_id>/approve', methods=['POST'])
+@login_required
+@app_admin_required
+@root_domain_only
+def approve_account(account_id):
+    """Move a pending signup to active so its users can log in."""
+    account = Account.query.get_or_404(account_id)
+    if account.status != 'pending':
+        flash(f'Account "{account.subdomain}" is not pending approval.', 'info')
+    else:
+        account.status = 'active'
+        master_db.session.commit()
+        flash(f'Approved "{account.company_name}" ({account.subdomain}).', 'success')
+    return redirect(url_for('app_admin.list_accounts'))
 
 
 @app_admin_bp.route('/admin/accounts/<int:account_id>/stats')

--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -4,10 +4,11 @@ from flask_migrate import Migrate
 from pathlib import Path
 from flask_login import LoginManager, current_user
 from flask_wtf.csrf import CSRFProtect
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
 from config import get_config
 import os
+# Limiter lives in utilities/extensions.py so blueprints can import it
+# without creating a circular import back to this module.
+from utilities.extensions import limiter
 
 # Master database (accounts, users)
 from utilities.master_database import master_db, MasterUser
@@ -40,13 +41,6 @@ login_manager = LoginManager()
 login_manager.login_view = "auth.login"
 
 csrf = CSRFProtect()
-
-limiter = Limiter(
-    key_func=get_remote_address,
-    default_limits=["200 per day", "50 per hour"],
-    storage_uri="memory://",
-    strategy="fixed-window"
-)
 
 
 def create_app():

--- a/templates/accounts/signup.html
+++ b/templates/accounts/signup.html
@@ -8,8 +8,17 @@
         <h1 class="text-3xl font-bold mb-2 text-gray-800">Create Your Company Account</h1>
         <p class="text-gray-600 mb-6">Start managing your keys, lockboxes, and signs today</p>
 
-        <form method="POST" id="signup-form" class="space-y-6">
+        <form method="POST" id="signup-form" class="space-y-6" autocomplete="on">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <!--
+              Honeypot: hidden from humans, often filled by spam bots that
+              auto-complete every input. Server rejects any submission with
+              this populated. Real users never see or touch it.
+            -->
+            <div aria-hidden="true" style="position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden;">
+                <label for="website">Website (leave blank)</label>
+                <input type="text" id="website" name="website" tabindex="-1" autocomplete="off">
+            </div>
             <!-- Company Information -->
             <div class="border-b pb-4">
                 <h2 class="text-xl font-semibold mb-4 text-gray-700">Company Information</h2>

--- a/templates/accounts/signup_pending.html
+++ b/templates/accounts/signup_pending.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Account submitted — KBM{% endblock %}
+
+{% block content %}
+<div class="form-shell">
+  <div class="card form-card text-center">
+    <h1 style="margin-bottom: 8px;">Account submitted</h1>
+    <p class="muted" style="margin: 0 0 24px;">
+      Awaiting administrator approval before <strong>{{ subdomain }}</strong> goes live.
+    </p>
+
+    <div style="text-align: left; max-width: 520px; margin: 0 auto;">
+      <div class="info-grid" style="grid-template-columns: 1fr;">
+        <div class="info-item">
+          <div class="info-label">Company</div>
+          <div class="info-value">{{ company_name }}</div>
+        </div>
+        <div class="info-item">
+          <div class="info-label">Subdomain</div>
+          <div class="info-value">{{ subdomain }}</div>
+        </div>
+        <div class="info-item">
+          <div class="info-label">Admin email</div>
+          <div class="info-value">{{ admin_email }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+    <p class="text-small muted">
+      You'll be able to log in once an administrator approves your account.
+      No further action is needed on your end.
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/templates/app_admin/accounts.html
+++ b/templates/app_admin/accounts.html
@@ -25,6 +25,18 @@
     color: var(--color-text);
     padding: 8px;
   }
+  .bulk-bar {
+    display: none;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    margin-bottom: 12px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent-soft);
+    border-radius: 10px;
+  }
+  .bulk-bar.is-visible { display: flex; }
+  .row-actions { display: flex; gap: 6px; flex-wrap: wrap; }
 </style>
 
 <div class="page-header">
@@ -35,6 +47,7 @@
   <form method="GET" class="toolbar">
     <select name="status" class="form-field" style="max-width: 200px;">
       <option value="all" {% if status_filter == 'all' %}selected{% endif %}>All Status</option>
+      <option value="pending" {% if status_filter == 'pending' %}selected{% endif %}>Pending Approval</option>
       <option value="active" {% if status_filter == 'active' %}selected{% endif %}>Active</option>
       <option value="suspended" {% if status_filter == 'suspended' %}selected{% endif %}>Suspended</option>
       <option value="deleted" {% if status_filter == 'deleted' %}selected{% endif %}>Deleted</option>
@@ -46,48 +59,137 @@
   </form>
 </div>
 
-<div class="card table-card">
-  <table>
-    <thead>
-      <tr>
-        <th>Company</th>
-        <th>Subdomain</th>
-        <th>Status</th>
-        <th>Users</th>
-        <th>Created</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for account in accounts %}
-      <tr>
-        <td>{{ account.company_name }}</td>
-        <td class="meta-cell">{{ account.subdomain }}</td>
-        <td>
-          {% if account.status == 'active' %}
-          <span class="tag ok">Active</span>
-          {% elif account.status == 'suspended' %}
-          <span class="tag warn">Suspended</span>
-          {% else %}
-          <span class="tag warn">{{ account.status }}</span>
-          {% endif %}
-        </td>
-        <td>{{ account.users|length }}</td>
-        <td class="text-small">{{ account.created_at.strftime('%Y-%m-%d') }}</td>
-        <td>
-          <a href="{{ url_for('app_admin.view_account', account_id=account.id) }}" class="btn small">
-            View
-          </a>
-        </td>
-      </tr>
-      {% else %}
-      <tr>
-        <td colspan="6" class="empty-state">
-          No accounts found
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+<form id="bulk-form" method="POST" action="{{ url_for('app_admin.bulk_delete_accounts') }}"
+      onsubmit="return confirmBulkDelete()">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+  <div class="bulk-bar" id="bulk-bar">
+    <strong><span id="bulk-count">0</span> selected</strong>
+    <button type="submit" class="btn danger small">Delete selected</button>
+    <button type="button" class="btn ghost small" onclick="clearSelection()">Clear</button>
+  </div>
+
+  <div class="card table-card">
+    <table>
+      <thead>
+        <tr>
+          <th style="width: 36px;">
+            <input type="checkbox" id="select-all" onchange="toggleAll(this)">
+          </th>
+          <th>Company</th>
+          <th>Subdomain</th>
+          <th>Status</th>
+          <th>Users</th>
+          <th>Created</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for account in accounts %}
+        <tr>
+          <td>
+            <input type="checkbox" name="account_ids" value="{{ account.id }}"
+                   class="row-check" onchange="updateBulkBar()">
+          </td>
+          <td>{{ account.company_name }}</td>
+          <td class="meta-cell">{{ account.subdomain }}</td>
+          <td>
+            {% if account.status == 'active' %}
+              <span class="tag ok">Active</span>
+            {% elif account.status == 'pending' %}
+              <span class="tag warn">Pending</span>
+            {% elif account.status == 'suspended' %}
+              <span class="tag warn">Suspended</span>
+            {% else %}
+              <span class="tag warn">{{ account.status }}</span>
+            {% endif %}
+          </td>
+          <td>{{ account.users|length }}</td>
+          <td class="text-small">{{ account.created_at.strftime('%Y-%m-%d') }}</td>
+          <td>
+            <div class="row-actions">
+              <a href="{{ url_for('app_admin.view_account', account_id=account.id) }}" class="btn small">View</a>
+              {% if account.status == 'pending' %}
+                <button type="button" class="btn small primary"
+                        onclick="approveAccount({{ account.id }}, '{{ account.subdomain }}')">Approve</button>
+              {% endif %}
+              <button type="button" class="btn small danger"
+                      onclick="deleteAccount({{ account.id }}, '{{ account.subdomain }}')">Delete</button>
+            </div>
+          </td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="7" class="empty-state">
+            No accounts found
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</form>
+
+<script>
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
+
+  function selectedRows() {
+    return document.querySelectorAll('.row-check:checked');
+  }
+
+  function updateBulkBar() {
+    const n = selectedRows().length;
+    const bar = document.getElementById('bulk-bar');
+    document.getElementById('bulk-count').textContent = n;
+    bar.classList.toggle('is-visible', n > 0);
+
+    // Sync the header checkbox state
+    const all = document.querySelectorAll('.row-check');
+    const allChecked = all.length > 0 && n === all.length;
+    document.getElementById('select-all').checked = allChecked;
+  }
+
+  function toggleAll(box) {
+    document.querySelectorAll('.row-check').forEach(cb => { cb.checked = box.checked; });
+    updateBulkBar();
+  }
+
+  function clearSelection() {
+    document.querySelectorAll('.row-check').forEach(cb => { cb.checked = false; });
+    document.getElementById('select-all').checked = false;
+    updateBulkBar();
+  }
+
+  function confirmBulkDelete() {
+    const n = selectedRows().length;
+    if (n === 0) return false;
+    return confirm(`Delete ${n} account${n === 1 ? '' : 's'} permanently? This drops the tenant database file too. Cannot be undone.`);
+  }
+
+  function postForm(action, fields) {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = action;
+    const csrf = document.createElement('input');
+    csrf.type = 'hidden'; csrf.name = 'csrf_token'; csrf.value = csrfToken;
+    form.appendChild(csrf);
+    Object.entries(fields).forEach(([k, v]) => {
+      const i = document.createElement('input');
+      i.type = 'hidden'; i.name = k; i.value = v;
+      form.appendChild(i);
+    });
+    document.body.appendChild(form);
+    form.submit();
+  }
+
+  function deleteAccount(id, subdomain) {
+    if (!confirm(`Permanently delete "${subdomain}"? This drops the tenant database file too. Cannot be undone.`)) return;
+    postForm(`/admin/accounts/${id}/delete`, { confirmed: 'quick' });
+  }
+
+  function approveAccount(id, subdomain) {
+    if (!confirm(`Approve "${subdomain}"? Its admin will be able to log in.`)) return;
+    postForm(`/admin/accounts/${id}/approve`, {});
+  }
+</script>
 {% endblock %}

--- a/utilities/extensions.py
+++ b/utilities/extensions.py
@@ -1,0 +1,20 @@
+"""
+Flask extensions that need to be importable from anywhere.
+
+Lives outside of `app_multitenant` so blueprints can import from this module
+without creating circular imports back to the app factory.
+"""
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+
+# Global rate limiter. The app factory in `app_multitenant` calls
+# `limiter.init_app(app)` only when RATELIMIT_ENABLED is true; until then
+# every `@limiter.limit(...)` decorator becomes a no-op, which is the
+# behavior we want for dev / unconfigured environments.
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["200 per day", "50 per hour"],
+    storage_uri="memory://",
+    strategy="fixed-window",
+)


### PR DESCRIPTION
## What

Three layers of bot prevention on signup, plus the tools to clean up the spam that's already there.

### Bot prevention
- **Honeypot** field on the signup form — invisible to humans, auto-filled by bots. Submissions with it populated get logged + dropped silently.
- **Rate limit** on POST /accounts/signup: 3/hour, 10/day per IP via Flask-Limiter.
- **Pending approval flow** — new signups land as \`status='pending'\`. The tenant middleware already 403s non-active accounts, so even if a bot squeaks past the other layers, the resulting account can't actually be used until you approve it.

### Cleanup tools
- **Bulk delete** on the accounts list — checkboxes per row, select-all in the header, sticky bulk-action bar. New \`/admin/accounts/bulk-delete\` route handles it in one request.
- **Per-row Delete** button uses a single confirm() instead of the type-the-subdomain dance (that ceremony stays in the Danger Zone on the detail page).
- **Per-row Approve** button on pending rows + new \`/admin/accounts/<id>/approve\` route.
- **Pending Approval** option in the status filter dropdown.

### Refactor cleanup
- Account deletion logic factored into \`_purge_account()\` so single and bulk paths share teardown.
- Removed a redundant manual \`MasterUser.query.delete()\` that happened before account deletion — Account.users cascade handles it via the ORM, which avoids potential FK-order bugs.
- \`limiter\` extracted from \`app_multitenant\` into \`utilities/extensions.py\` so blueprints can import it without circular dependencies.

## Why now

You're being actively spammed and the existing single-account delete (type the subdomain to confirm, per account) made cleanup unusable.

## Test plan
- [ ] Sign up normally — should land on the new \`signup_pending.html\` page (not redirect to the subdomain)
- [ ] Try to log in to the new tenant subdomain — should get 403 until approved from app admin
- [ ] App admin: filter by Pending → see new account → click Approve → log in succeeds
- [ ] App admin: select a few spam accounts via checkbox → Delete selected → all gone in one click
- [ ] Submit signup form with honeypot field populated (via devtools) — should silently "succeed" without creating an account