### PR TITLE
Fix in-app updater: drop :ro on entrypoint mounts, chown the whole repo

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,8 +25,11 @@ services:
       # Source mounts so the in-app system update can pull code without a rebuild.
       # IMPORTANT: when you add a new top-level Python file or blueprint package,
       # add it here too — otherwise `git pull` won't reach the running container.
-      - ./app_multitenant.py:/app/app_multitenant.py:ro
-      - ./config.py:/app/config.py:ro
+      # NOT read-only — the in-app updater runs `git pull` from inside the
+      # container and needs to be able to write to these files when they
+      # change upstream.
+      - ./app_multitenant.py:/app/app_multitenant.py
+      - ./config.py:/app/config.py
       - ./templates:/app/templates
       - ./static:/app/static
       - ./audits:/app/audits

--- a/deploy/install_vps.sh
+++ b/deploy/install_vps.sh
@@ -94,19 +94,18 @@ fi
 APP_UID=1000
 APP_GID=1000
 
-log "Ensuring data directories exist and are owned by UID ${APP_UID}"
+log "Ensuring data directories exist"
 mkdir -p master_db tenant_dbs backups logs
-chown -R "${APP_UID}:${APP_GID}" master_db tenant_dbs backups logs
 
-# .git is bind-mounted so the in-app system-update feature can git pull.
-# appuser inside the container needs to be able to write new objects (every
-# fetch creates new files in .git/objects), so the simplest reliable fix is
-# to chown the directory to appuser. chmod alone doesn't survive — git
-# creates new files with default permissions on each operation, and "other"
-# write bits don't propagate.
-if [[ -d .git ]]; then
-	chown -R "${APP_UID}:${APP_GID}" .git
-fi
+# Chown the entire repo to appuser. This covers:
+#   - data dirs (master_db, tenant_dbs, backups, logs)
+#   - .git (so the in-app updater can `git fetch` / `git pull`)
+#   - source files (so `git pull` can replace them — git replaces files via
+#     atomic rename, which requires write access to the parent directory)
+# Doing the whole tree once is simpler than chasing each subdirectory,
+# and on a single-purpose VPS the host root user retains full access.
+log "Ensuring repo + data dirs are owned by UID ${APP_UID} (for in-container appuser)"
+chown -R "${APP_UID}:${APP_GID}" "${REPO_ROOT}"
 
 # ------------------------------------------------------------------------------
 # 5. Sanity-check the env values that need human input


### PR DESCRIPTION
## What

Two fixes to make the in-app system updater actually work end-to-end:

1. **compose.yaml** — drop \`:ro\` from the \`app_multitenant.py\` and \`config.py\` bind mounts. The updater runs \`git pull\` from inside the container; git wants to atomically replace tracked files via rename, which fails on a read-only mount with \`Device or resource busy\`.

2. **deploy/install_vps.sh** — chown the **entire** \`/opt/kbm\` to appuser, not just the data directories. The source tree was previously root-owned (operator runs as root on the VPS), so \`git pull\` from the container couldn't unlink the root-owned versions when updating files.

## Why

The user just hit:
\`\`\`
error: unable to unlink old 'accounts/routes.py': Permission denied
error: unable to unlink old 'app_multitenant.py': Device or resource busy
error: unable to create file utilities/extensions.py: Permission denied
\`\`\`
on Update Now after merging the spam-fix PR.

## Existing deployments

Need a one-time \`chown -R 1000:1000 /opt/kbm\` on the host before the next \`docker compose up -d\` picks up the compose change. After that the in-app updater works for all future code changes.

## Test plan
- [ ] Pull on VPS, run \`chown -R 1000:1000 /opt/kbm\`, run \`docker compose up -d\`
- [ ] Hit Update Now in the system update UI when there's a real change to pull → should succeed
- [ ] Tail \`docker compose logs python-app\` for any new errors