### PR TITLE
Smart locks: pairing fields + image uploads + edit/delete

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,7 @@ services:
       - ./master_db:/app/master_db
       - ./tenant_dbs:/app/tenant_dbs
       - ./backups:/app/backups
+      - ./uploads:/app/uploads
       - /var/run/docker.sock:/var/run/docker.sock
       # Source mounts so the in-app system update can pull code without a rebuild.
       # IMPORTANT: when you add a new top-level Python file or blueprint package,

--- a/deploy/install_vps.sh
+++ b/deploy/install_vps.sh
@@ -95,7 +95,7 @@ APP_UID=1000
 APP_GID=1000
 
 log "Ensuring data directories exist"
-mkdir -p master_db tenant_dbs backups logs
+mkdir -p master_db tenant_dbs backups logs uploads
 
 # Chown the entire repo to appuser. This covers:
 #   - data dirs (master_db, tenant_dbs, backups, logs)

--- a/smartlocks/views.py
+++ b/smartlocks/views.py
@@ -1,18 +1,83 @@
-﻿from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+import logging
+import os
+import uuid
+from pathlib import Path
+
+from flask import (
+    Blueprint, render_template, request, redirect, url_for, flash, abort,
+    send_from_directory, current_app, g,
+)
 from flask_login import login_required, current_user
 from sqlalchemy import or_
+from werkzeug.utils import secure_filename
 
-from utilities.tenant_helpers import tenant_query, tenant_add, tenant_commit, tenant_rollback, get_tenant_session
+from utilities.tenant_helpers import (
+    tenant_query, tenant_add, tenant_commit, tenant_rollback, tenant_delete, get_tenant_session,
+)
 from middleware.tenant_middleware import tenant_required
-from utilities.database import db, SmartLock, Property, PropertyUnit, log_activity
+from utilities.database import db, SmartLock, SmartLockImage, Property, PropertyUnit, log_activity
+
+log = logging.getLogger(__name__)
 
 smartlocks_bp = Blueprint(
     "smartlocks",
     __name__,
     template_folder="../templates",
-    static_folder="../static"
+    static_folder="../static",
 )
 
+
+# ---------------------------------------------------------------------------
+# Image upload constraints + helpers
+# ---------------------------------------------------------------------------
+
+ALLOWED_IMAGE_EXTS = {"jpg", "jpeg", "png", "gif", "webp"}
+ALLOWED_IMAGE_MIMES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MiB per image
+
+
+def _uploads_root() -> Path:
+    """Filesystem root for tenant-scoped uploads. Created lazily."""
+    base = Path(current_app.root_path) / "uploads"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _smartlock_upload_dir(lock: SmartLock) -> Path:
+    """Per-tenant, per-lock upload directory. Tenant subdomain in the path
+    keeps things visibly separated on disk; the actual access control is
+    the tenant context check at serve time."""
+    tenant = g.get("tenant")
+    if tenant is None:
+        abort(404)
+    subdir = _uploads_root() / tenant.subdomain / "smartlocks" / str(lock.id)
+    subdir.mkdir(parents=True, exist_ok=True)
+    return subdir
+
+
+def _ext_of(filename: str) -> str:
+    return filename.rsplit(".", 1)[1].lower() if "." in filename else ""
+
+
+def _looks_like_an_image(file_storage) -> bool:
+    """Verify the uploaded file is actually an image, not just a renamed
+    text file. Reads the file header via Pillow and rejects if parsing fails."""
+    try:
+        from PIL import Image
+        pos = file_storage.stream.tell()
+        try:
+            with Image.open(file_storage.stream) as img:
+                img.verify()
+            return True
+        finally:
+            file_storage.stream.seek(pos)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
 
 def _get_smartlock_or_404(lock_id: int) -> SmartLock:
     smart_lock = get_tenant_session().get(SmartLock, lock_id)
@@ -20,6 +85,56 @@ def _get_smartlock_or_404(lock_id: int) -> SmartLock:
         abort(404)
     return smart_lock
 
+
+def _resolve_property_and_unit(property_id_str: str, unit_id_str: str):
+    """Returns (property_obj, unit_obj, error_messages). Either object can
+    be None — both fields are optional on the form."""
+    errors: list[str] = []
+    property_ref = None
+    if property_id_str:
+        try:
+            property_ref = get_tenant_session().get(Property, int(property_id_str))
+        except ValueError:
+            property_ref = None
+        if property_ref is None:
+            errors.append("Selected property could not be found.")
+
+    unit_ref = None
+    if unit_id_str:
+        try:
+            unit_ref = get_tenant_session().get(PropertyUnit, int(unit_id_str))
+        except ValueError:
+            unit_ref = None
+        if unit_ref is None:
+            errors.append("Selected unit could not be found.")
+    return property_ref, unit_ref, errors
+
+
+def _form_str(name: str) -> str | None:
+    """Pull a stripped form value, returning None when empty (so we store
+    NULL instead of empty strings on optional fields)."""
+    raw = (request.form.get(name) or "").strip()
+    return raw or None
+
+
+def _apply_smartlock_form(lock: SmartLock):
+    """Copy form fields onto a SmartLock instance. Caller is responsible
+    for required-field validation and committing the session."""
+    lock.label = (request.form.get("label") or "").strip() or lock.label
+    lock.code = (request.form.get("code") or "").strip() or lock.code
+    lock.provider = _form_str("provider")
+    lock.backup_code = _form_str("backup_code")
+    lock.instructions = _form_str("instructions")
+    lock.notes = _form_str("notes")
+    lock.model_number = _form_str("model_number")
+    lock.serial_number = _form_str("serial_number")
+    lock.pairing_code = _form_str("pairing_code")
+    lock.qr_code_data = _form_str("qr_code_data")
+
+
+# ---------------------------------------------------------------------------
+# CRUD routes
+# ---------------------------------------------------------------------------
 
 @smartlocks_bp.route("/", methods=["GET"])
 @login_required
@@ -34,6 +149,8 @@ def list_smartlocks():
                 SmartLock.label.ilike(like),
                 SmartLock.code.ilike(like),
                 SmartLock.provider.ilike(like),
+                SmartLock.model_number.ilike(like),
+                SmartLock.serial_number.ilike(like),
             )
         )
     locks = query.order_by(SmartLock.label.asc()).all()
@@ -50,12 +167,6 @@ def create_smartlock():
     if request.method == "POST":
         label = (request.form.get("label") or "").strip()
         code = (request.form.get("code") or "").strip()
-        provider = (request.form.get("provider") or "").strip() or None
-        backup_code = (request.form.get("backup_code") or "").strip() or None
-        instructions = (request.form.get("instructions") or "").strip() or None
-        notes = (request.form.get("notes") or "").strip() or None
-        property_id_str = (request.form.get("property_id") or "").strip()
-        unit_id_str = (request.form.get("property_unit_id") or "").strip()
 
         errors: list[str] = []
         if not label:
@@ -63,39 +174,22 @@ def create_smartlock():
         if not code:
             errors.append("Code is required.")
 
-        property_ref = None
-        if property_id_str:
-            try:
-                property_ref = get_tenant_session().get(Property, int(property_id_str))
-            except ValueError:
-                property_ref = None
-            if property_ref is None:
-                errors.append("Selected property could not be found.")
-
-        unit_ref = None
-        if unit_id_str:
-            try:
-                unit_ref = get_tenant_session().get(PropertyUnit, int(unit_id_str))
-            except ValueError:
-                unit_ref = None
-            if unit_ref is None:
-                errors.append("Selected unit could not be found.")
+        property_ref, unit_ref, prop_errors = _resolve_property_and_unit(
+            (request.form.get("property_id") or "").strip(),
+            (request.form.get("property_unit_id") or "").strip(),
+        )
+        errors.extend(prop_errors)
 
         if errors:
             for message in errors:
                 flash(message, "error")
             return redirect(url_for("smartlocks.create_smartlock"))
 
-        smart_lock = SmartLock(
-            label=label,
-            code=code,
-            provider=provider,
-            backup_code=backup_code,
-            instructions=instructions,
-            notes=notes,
-            property=property_ref,
-            property_unit=unit_ref,
-        )
+        smart_lock = SmartLock(label=label, code=code)
+        _apply_smartlock_form(smart_lock)
+        smart_lock.property = property_ref
+        smart_lock.property_unit = unit_ref
+
         tenant_add(smart_lock)
         tenant_commit()
         flash("Smart lock saved.", "success")
@@ -120,6 +214,195 @@ def smartlock_detail(lock_id: int):
     return render_template("smartlock_detail.html", smartlock=smart_lock)
 
 
+@smartlocks_bp.route("/<int:lock_id>/edit", methods=["GET", "POST"])
+@login_required
+@tenant_required
+def edit_smartlock(lock_id: int):
+    smart_lock = _get_smartlock_or_404(lock_id)
+    properties = tenant_query(Property).order_by(Property.name.asc()).all()
+    property_units = tenant_query(PropertyUnit).order_by(PropertyUnit.label.asc()).all()
+
+    if request.method == "POST":
+        label = (request.form.get("label") or "").strip()
+        code = (request.form.get("code") or "").strip()
+
+        errors: list[str] = []
+        if not label:
+            errors.append("Label is required.")
+        if not code:
+            errors.append("Code is required.")
+
+        property_ref, unit_ref, prop_errors = _resolve_property_and_unit(
+            (request.form.get("property_id") or "").strip(),
+            (request.form.get("property_unit_id") or "").strip(),
+        )
+        errors.extend(prop_errors)
+
+        if errors:
+            for message in errors:
+                flash(message, "error")
+            return redirect(url_for("smartlocks.edit_smartlock", lock_id=lock_id))
+
+        _apply_smartlock_form(smart_lock)
+        smart_lock.property = property_ref
+        smart_lock.property_unit = unit_ref
+
+        tenant_commit()
+        flash("Smart lock updated.", "success")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+    return render_template(
+        "smartlock_form.html",
+        smartlock=smart_lock,
+        properties=properties,
+        property_units=property_units,
+        form_action=url_for("smartlocks.edit_smartlock", lock_id=lock_id),
+        page_title=f"Edit {smart_lock.label}",
+        submit_label="Save Changes",
+    )
+
+
+@smartlocks_bp.route("/<int:lock_id>/delete", methods=["POST"])
+@login_required
+@tenant_required
+def delete_smartlock(lock_id: int):
+    smart_lock = _get_smartlock_or_404(lock_id)
+    label = smart_lock.label
+
+    # Best-effort cleanup of on-disk image files. SmartLockImage rows are
+    # cascade-deleted via the ORM relationship.
+    try:
+        upload_dir = _smartlock_upload_dir(smart_lock)
+        for image in smart_lock.images:
+            file_path = upload_dir / image.filename
+            if file_path.exists():
+                file_path.unlink()
+        try:
+            upload_dir.rmdir()
+        except OSError:
+            pass  # not empty, leave it
+    except Exception:
+        log.exception("smartlock %s: failed to clean up upload dir during delete", lock_id)
+
+    tenant_delete(smart_lock)
+    tenant_commit()
+    flash(f'Smart lock "{label}" deleted.', "success")
+    return redirect(url_for("smartlocks.list_smartlocks"))
+
+
+# ---------------------------------------------------------------------------
+# Image routes
+# ---------------------------------------------------------------------------
+
+@smartlocks_bp.route("/<int:lock_id>/images/upload", methods=["POST"])
+@login_required
+@tenant_required
+def upload_smartlock_image(lock_id: int):
+    """Accept one image file + optional caption, store on disk + DB row."""
+    smart_lock = _get_smartlock_or_404(lock_id)
+
+    file = request.files.get("image")
+    caption = (request.form.get("caption") or "").strip() or None
+
+    if not file or not file.filename:
+        flash("Choose a file to upload.", "error")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+    ext = _ext_of(secure_filename(file.filename))
+    if ext not in ALLOWED_IMAGE_EXTS:
+        flash(f"Unsupported file type. Allowed: {', '.join(sorted(ALLOWED_IMAGE_EXTS))}", "error")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+    if file.mimetype and file.mimetype not in ALLOWED_IMAGE_MIMES:
+        flash(f"Unsupported image type: {file.mimetype}", "error")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+    file.stream.seek(0, os.SEEK_END)
+    size = file.stream.tell()
+    file.stream.seek(0)
+    if size <= 0:
+        flash("Uploaded file is empty.", "error")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+    if size > MAX_IMAGE_BYTES:
+        mb = MAX_IMAGE_BYTES // (1024 * 1024)
+        flash(f"File too large ({size // 1024 // 1024} MiB). Limit is {mb} MiB.", "error")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+    if not _looks_like_an_image(file):
+        flash("That file doesn't look like a valid image.", "error")
+        return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+    stored_name = f"{uuid.uuid4().hex}.{ext}"
+    upload_dir = _smartlock_upload_dir(smart_lock)
+    target = upload_dir / stored_name
+    file.save(str(target))
+
+    record = SmartLockImage(
+        smart_lock_id=smart_lock.id,
+        filename=stored_name,
+        original_filename=secure_filename(file.filename),
+        caption=caption,
+        content_type=file.mimetype,
+        size_bytes=size,
+        uploaded_by_id=getattr(current_user, "id", None),
+    )
+    tenant_add(record)
+    tenant_commit()
+
+    flash("Image uploaded.", "success")
+    return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+
+@smartlocks_bp.route("/<int:lock_id>/images/<int:image_id>", methods=["GET"])
+@login_required
+@tenant_required
+def serve_smartlock_image(lock_id: int, image_id: int):
+    """Serve an image file. Tenant-scoped: the request must be on the
+    tenant's subdomain (enforced by @tenant_required) AND the image must
+    belong to a smart lock in this tenant's DB."""
+    smart_lock = _get_smartlock_or_404(lock_id)
+    image = get_tenant_session().get(SmartLockImage, image_id)
+    if image is None or image.smart_lock_id != smart_lock.id:
+        abort(404)
+
+    upload_dir = _smartlock_upload_dir(smart_lock)
+    if not (upload_dir / image.filename).exists():
+        abort(404)
+
+    return send_from_directory(
+        upload_dir,
+        image.filename,
+        download_name=image.original_filename or image.filename,
+        as_attachment=False,
+    )
+
+
+@smartlocks_bp.route("/<int:lock_id>/images/<int:image_id>/delete", methods=["POST"])
+@login_required
+@tenant_required
+def delete_smartlock_image(lock_id: int, image_id: int):
+    smart_lock = _get_smartlock_or_404(lock_id)
+    image = get_tenant_session().get(SmartLockImage, image_id)
+    if image is None or image.smart_lock_id != smart_lock.id:
+        abort(404)
+
+    try:
+        file_path = _smartlock_upload_dir(smart_lock) / image.filename
+        if file_path.exists():
+            file_path.unlink()
+    except Exception:
+        log.exception("smartlock image %s: failed to delete file", image_id)
+
+    tenant_delete(image)
+    tenant_commit()
+    flash("Image deleted.", "success")
+    return redirect(url_for("smartlocks.smartlock_detail", lock_id=lock_id))
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
 @smartlocks_bp.route("/export", methods=["GET"])
 @login_required
 @tenant_required
@@ -139,6 +422,8 @@ def export_smartlocks():
                 SmartLock.label.ilike(like),
                 SmartLock.code.ilike(like),
                 SmartLock.provider.ilike(like),
+                SmartLock.model_number.ilike(like),
+                SmartLock.serial_number.ilike(like),
             )
         )
     locks = query.order_by(SmartLock.label.asc()).all()
@@ -150,6 +435,10 @@ def export_smartlocks():
             "Code": lock.code or "",
             "Provider": lock.provider or "",
             "Backup Code": lock.backup_code or "",
+            "Model Number": lock.model_number or "",
+            "Serial Number": lock.serial_number or "",
+            "Pairing Code": lock.pairing_code or "",
+            "QR Code Data": lock.qr_code_data or "",
             "Instructions": lock.instructions or "",
             "Notes": lock.notes or "",
             "Property": lock.property.name if lock.property else "",
@@ -160,4 +449,3 @@ def export_smartlocks():
     if format_type == "excel":
         return generate_excel(data, f"smartlocks_{timestamp}.xlsx")
     return generate_csv(data, f"smartlocks_{timestamp}.csv")
-

--- a/templates/smartlock_detail.html
+++ b/templates/smartlock_detail.html
@@ -1,11 +1,84 @@
-﻿{% extends "base.html" %}
+{% extends "base.html" %}
 {% block title %}{{ smartlock.label }} - Smart Lock{% endblock %}
+
+{% block head %}
+<style>
+  .image-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 14px;
+    margin-top: 12px;
+  }
+  .image-tile {
+    position: relative;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+    background: var(--color-card);
+    display: flex;
+    flex-direction: column;
+  }
+  .image-tile a.thumb {
+    display: block;
+    aspect-ratio: 1 / 1;
+    overflow: hidden;
+    background: rgba(148, 163, 184, 0.06);
+  }
+  .image-tile a.thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.2s ease;
+  }
+  .image-tile a.thumb:hover img { transform: scale(1.04); }
+  .image-tile-meta {
+    padding: 8px 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--color-muted);
+  }
+  .image-tile-caption {
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .image-tile-delete {
+    border: none;
+    background: none;
+    color: var(--color-danger);
+    cursor: pointer;
+    font-size: 13px;
+    padding: 0;
+  }
+  .image-tile-delete:hover { text-decoration: underline; }
+  .upload-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: flex-end;
+    margin-top: 12px;
+  }
+  .upload-form .form-field { flex: 1 1 220px; }
+</style>
+{% endblock %}
 
 {% block content %}
 <div class="page-header">
   <h1>{{ smartlock.label }}</h1>
   <div class="toolbar">
     <a class="btn" href="{{ url_for('smartlocks.list_smartlocks') }}">Back</a>
+    <a class="btn ghost" href="{{ url_for('smartlocks.edit_smartlock', lock_id=smartlock.id) }}">Edit</a>
+    <form method="post" action="{{ url_for('smartlocks.delete_smartlock', lock_id=smartlock.id) }}"
+          style="display: inline;"
+          onsubmit="return confirm('Delete this smart lock and all its images? This cannot be undone.');">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <button type="submit" class="btn danger">Delete</button>
+    </form>
   </div>
 </div>
 
@@ -53,5 +126,86 @@
     </div>
   {% endif %}
 </div>
-{% endblock %}
 
+{% if smartlock.model_number or smartlock.serial_number or smartlock.pairing_code or smartlock.qr_code_data %}
+<div class="card" style="margin-top: 18px;">
+  <h2>Manufacturer Details</h2>
+  <div class="info-grid">
+    {% if smartlock.model_number %}
+    <div class="info-item">
+      <div class="info-label">Model Number</div>
+      <div class="info-value"><code>{{ smartlock.model_number }}</code></div>
+    </div>
+    {% endif %}
+    {% if smartlock.serial_number %}
+    <div class="info-item">
+      <div class="info-label">Serial Number</div>
+      <div class="info-value"><code>{{ smartlock.serial_number }}</code></div>
+    </div>
+    {% endif %}
+    {% if smartlock.pairing_code %}
+    <div class="info-item">
+      <div class="info-label">Pairing Code</div>
+      <div class="info-value"><code>{{ smartlock.pairing_code }}</code></div>
+    </div>
+    {% endif %}
+    {% if smartlock.qr_code_data %}
+    <div class="info-item">
+      <div class="info-label">QR Code Data</div>
+      <div class="info-value" style="word-break: break-all;"><code>{{ smartlock.qr_code_data }}</code></div>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+
+<div class="card" style="margin-top: 18px;">
+  <h2>Images
+    {% if smartlock.images %}<span class="muted text-small" style="font-weight: 400;">({{ smartlock.images|length }})</span>{% endif %}
+  </h2>
+
+  {% if smartlock.images %}
+    <div class="image-gallery">
+      {% for image in smartlock.images %}
+        <div class="image-tile">
+          <a class="thumb" href="{{ url_for('smartlocks.serve_smartlock_image', lock_id=smartlock.id, image_id=image.id) }}" target="_blank" rel="noopener">
+            <img src="{{ url_for('smartlocks.serve_smartlock_image', lock_id=smartlock.id, image_id=image.id) }}"
+                 alt="{{ image.caption or image.original_filename or 'Smart lock image' }}"
+                 loading="lazy">
+          </a>
+          <div class="image-tile-meta">
+            <span class="image-tile-caption" title="{{ image.caption or image.original_filename or '' }}">
+              {{ image.caption or image.original_filename or 'Image' }}
+            </span>
+            <form method="post" action="{{ url_for('smartlocks.delete_smartlock_image', lock_id=smartlock.id, image_id=image.id) }}"
+                  style="display: inline;"
+                  onsubmit="return confirm('Delete this image? Cannot be undone.');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <button type="submit" class="image-tile-delete" title="Delete">×</button>
+            </form>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="muted text-small" style="margin: 8px 0 0;">No images yet — upload one below.</p>
+  {% endif %}
+
+  <form class="upload-form"
+        method="post"
+        action="{{ url_for('smartlocks.upload_smartlock_image', lock_id=smartlock.id) }}"
+        enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <div class="form-field">
+      <label for="image">Image File</label>
+      <input type="file" id="image" name="image" accept="image/jpeg,image/png,image/gif,image/webp" required>
+      <small class="muted">JPEG, PNG, GIF, or WebP. Max 10 MiB.</small>
+    </div>
+    <div class="form-field">
+      <label for="caption">Caption (optional)</label>
+      <input type="text" id="caption" name="caption" placeholder="e.g. Pairing sticker on manual">
+    </div>
+    <button type="submit" class="btn primary">Upload</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/smartlock_form.html
+++ b/templates/smartlock_form.html
@@ -73,6 +73,30 @@
         </div>
       </div>
 
+      <h3 style="margin-top: 24px;">Manufacturer Details</h3>
+      <p class="muted text-small" style="margin-top: -10px; margin-bottom: 12px;">
+        Optional. Useful for re-pairing locks (Schlage, August, etc.) where the
+        sticker inside the manual is the only place these are printed.
+      </p>
+      <div class="form-grid two-column">
+        <div class="form-field">
+          <label for="model_number">Model Number</label>
+          <input type="text" id="model_number" name="model_number" value="{{ smartlock.model_number if smartlock else '' }}" placeholder="e.g. BE489WB CAM">
+        </div>
+        <div class="form-field">
+          <label for="serial_number">Serial Number</label>
+          <input type="text" id="serial_number" name="serial_number" value="{{ smartlock.serial_number if smartlock else '' }}">
+        </div>
+        <div class="form-field">
+          <label for="pairing_code">Pairing Code</label>
+          <input type="text" id="pairing_code" name="pairing_code" value="{{ smartlock.pairing_code if smartlock else '' }}" placeholder="On the sticker">
+        </div>
+        <div class="form-field">
+          <label for="qr_code_data">QR Code Data</label>
+          <input type="text" id="qr_code_data" name="qr_code_data" value="{{ smartlock.qr_code_data if smartlock else '' }}" placeholder="What the sticker QR encodes">
+        </div>
+      </div>
+
       <div class="form-field">
         <label for="instructions">Instructions</label>
         <textarea id="instructions" name="instructions" rows="3">{{ smartlock.instructions if smartlock else '' }}</textarea>
@@ -84,7 +108,11 @@
 
       <div class="toolbar spaced">
         <button type="submit" class="btn primary">{{ submit_label }}</button>
-        <a class="btn ghost" href="{{ url_for('smartlocks.list_smartlocks') }}">Cancel</a>
+        {% if smartlock %}
+          <a class="btn ghost" href="{{ url_for('smartlocks.smartlock_detail', lock_id=smartlock.id) }}">Cancel</a>
+        {% else %}
+          <a class="btn ghost" href="{{ url_for('smartlocks.list_smartlocks') }}">Cancel</a>
+        {% endif %}
       </div>
     </form>
   </div>

--- a/utilities/database.py
+++ b/utilities/database.py
@@ -358,6 +358,15 @@ class SmartLock(db.Model):
     backup_code = db.Column(db.String(120), nullable=True)
     instructions = db.Column(db.Text, nullable=True)
     notes = db.Column(db.Text, nullable=True)
+
+    # Manufacturer / pairing details. All optional — useful for re-pairing
+    # locks like Schlage Encode where the pairing QR + code only live on the
+    # sticker inside the manual.
+    model_number = db.Column(db.String(120), nullable=True)
+    serial_number = db.Column(db.String(120), nullable=True)
+    pairing_code = db.Column(db.String(120), nullable=True)
+    qr_code_data = db.Column(db.Text, nullable=True)
+
     property_id = db.Column(db.Integer, db.ForeignKey("properties.id"), nullable=True, index=True)
     property_unit_id = db.Column(db.Integer, db.ForeignKey("property_units.id"), nullable=True, index=True)
     created_at = db.Column(db.DateTime, nullable=False, default=utc_now)
@@ -365,6 +374,12 @@ class SmartLock(db.Model):
 
     property = db.relationship("Property", back_populates="smart_locks")
     property_unit = db.relationship("PropertyUnit", back_populates="smart_locks")
+    images = db.relationship(
+        "SmartLockImage",
+        back_populates="smart_lock",
+        cascade="all, delete-orphan",
+        order_by="SmartLockImage.uploaded_at",
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -375,8 +390,49 @@ class SmartLock(db.Model):
             "backup_code": self.backup_code,
             "instructions": self.instructions,
             "notes": self.notes,
+            "model_number": self.model_number,
+            "serial_number": self.serial_number,
+            "pairing_code": self.pairing_code,
+            "qr_code_data": self.qr_code_data,
             "property_id": self.property_id,
             "property_unit_id": self.property_unit_id,
+        }
+
+
+class SmartLockImage(db.Model):
+    """A single uploaded image attached to a SmartLock — typically a photo of
+    the lock itself, the pairing-code sticker from the manual, etc."""
+    __tablename__ = "smart_lock_images"
+
+    id = db.Column(db.Integer, primary_key=True)
+    smart_lock_id = db.Column(
+        db.Integer,
+        db.ForeignKey("smart_locks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # filename stored on disk (UUID-prefixed to avoid collisions)
+    filename = db.Column(db.String(255), nullable=False)
+    # what the user uploaded — preserved for download
+    original_filename = db.Column(db.String(255), nullable=True)
+    caption = db.Column(db.String(255), nullable=True)
+    content_type = db.Column(db.String(120), nullable=True)
+    size_bytes = db.Column(db.Integer, nullable=True)
+    uploaded_at = db.Column(db.DateTime, nullable=False, default=utc_now)
+    uploaded_by_id = db.Column(db.Integer, nullable=True)
+
+    smart_lock = db.relationship("SmartLock", back_populates="images")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "smart_lock_id": self.smart_lock_id,
+            "filename": self.filename,
+            "original_filename": self.original_filename,
+            "caption": self.caption,
+            "content_type": self.content_type,
+            "size_bytes": self.size_bytes,
+            "uploaded_at": self.uploaded_at.isoformat() if self.uploaded_at else None,
         }
 
 

--- a/utilities/tenant_schema.py
+++ b/utilities/tenant_schema.py
@@ -47,6 +47,26 @@ def add_column_if_missing(table: str, column: str, ddl: str) -> Callable:
     return _upgrade
 
 
+def create_table_if_missing(table: str, ddl: str) -> Callable:
+    """Return an upgrade callable that creates a table if it doesn't exist.
+
+    `ddl` is the full column-list portion of CREATE TABLE, without the
+    `CREATE TABLE name (...)` wrapper. Example:
+        '"id" INTEGER PRIMARY KEY, "smart_lock_id" INTEGER NOT NULL'
+    """
+    def _upgrade(engine, db_path: Path) -> bool:
+        insp = inspect(engine)
+        if insp.has_table(table):
+            return False
+        with engine.begin() as conn:
+            conn.execute(text(f'CREATE TABLE "{table}" ({ddl})'))
+        log.info("[%s] created table %s", db_path.name, table)
+        return True
+
+    _upgrade.__name__ = f"create_{table}"
+    return _upgrade
+
+
 # ----------------------------------------------------------------------------
 # All tenant upgrades. Each one is idempotent.
 # ----------------------------------------------------------------------------
@@ -57,6 +77,26 @@ TENANT_UPGRADES: list[Callable] = [
         table="item_checkouts",
         column="contact_id",
         ddl='INTEGER REFERENCES "contacts"("id") ON DELETE SET NULL',
+    ),
+    # Smart-lock pairing/manufacturer details (often only printed on the
+    # sticker that ships with the device — useful to capture before the
+    # sticker is lost).
+    add_column_if_missing("smart_locks", "model_number", "VARCHAR(120)"),
+    add_column_if_missing("smart_locks", "serial_number", "VARCHAR(120)"),
+    add_column_if_missing("smart_locks", "pairing_code", "VARCHAR(120)"),
+    add_column_if_missing("smart_locks", "qr_code_data", "TEXT"),
+    # Image attachments per smart lock (photo of unit, sticker, etc.)
+    create_table_if_missing(
+        "smart_lock_images",
+        '"id" INTEGER NOT NULL PRIMARY KEY, '
+        '"smart_lock_id" INTEGER NOT NULL REFERENCES "smart_locks"("id") ON DELETE CASCADE, '
+        '"filename" VARCHAR(255) NOT NULL, '
+        '"original_filename" VARCHAR(255), '
+        '"caption" VARCHAR(255), '
+        '"content_type" VARCHAR(120), '
+        '"size_bytes" INTEGER, '
+        '"uploaded_at" DATETIME NOT NULL, '
+        '"uploaded_by_id" INTEGER'
     ),
 ]
 


### PR DESCRIPTION
## What

Smart locks gain four new optional fields, multi-image attachments, an edit form, and a delete button.

### Why

You asked for this so the pairing data on Schlage / similar lock stickers (model #, serial #, pairing code, QR data) lives in the app and the manual can be tossed. Plus a photo of the sticker as a backup, plus a photo of the lock itself for identification.

### New fields on SmartLock (all optional)
- \`model_number\`, \`serial_number\`, \`pairing_code\`, \`qr_code_data\`

### New SmartLockImage model
- One-to-many to SmartLock, cascade-delete.
- Stores filename, original_filename, caption, content_type, size_bytes, uploaded_at, uploaded_by_id.

### Storage layout
- Files live at \`uploads/<tenant-subdomain>/smartlocks/<lock_id>/<uuid>.<ext>\` on the host.
- New bind mount \`./uploads:/app/uploads\` in compose.yaml.
- \`install_vps.sh\` creates the dir and the existing whole-repo chown picks it up.

### Image security
- Upload validates: extension allowlist, MIME allowlist, 10 MiB size cap, and Pillow actually parses the file to confirm it's a real image (catches renamed text files).
- Serving is tenant-scoped twice: \`@tenant_required\` ensures the request is on a tenant subdomain, and the route checks that the requested image's \`smart_lock_id\` matches the URL's \`lock_id\` in this tenant's DB. Other tenants' files cannot be addressed even by guessing IDs.

### New routes
- \`GET/POST /smart-locks/<id>/edit\` — edit existing lock (form is the same template as create)
- \`POST /smart-locks/<id>/delete\` — delete lock + all its images (on-disk best effort)
- \`POST /smart-locks/<id>/images/upload\`
- \`GET /smart-locks/<id>/images/<image_id>\` — serve the file
- \`POST /smart-locks/<id>/images/<image_id>/delete\`

### Schema migration
- New \`create_table_if_missing()\` helper in \`utilities/tenant_schema.py\` for table-level upgrades.
- Idempotent migrations for the four new columns and the new table. Run automatically at app startup.

## Deploy notes

1. Merge.
2. On VPS: \`git pull && docker compose up -d\` (the \`up -d\` is needed to pick up the new \`uploads/\` mount).
3. Container start logs should show \`[<tenant>.db] added column smart_locks.model_number\` etc. and \`created table smart_lock_images\`.

## Test plan
- [ ] Edit an existing smart lock, fill in the new fields, save → fields show on detail page
- [ ] Upload a JPEG to a smart lock → appears in the gallery, click opens full size
- [ ] Try to upload a 20 MiB file → rejected
- [ ] Try to upload \`config.py\` renamed to \`.jpg\` → rejected by Pillow validation
- [ ] Delete an image → file gone from disk + row gone from DB
- [ ] Delete a smart lock with images → images gone too
- [ ] As tenant A, try to access \`/smart-locks/<tenantB-lock-id>/images/<id>\` → 404