### PR TITLE
Updater: read compose labels from Config.Labels (was reading wrong path, silently no-op'ing the sidecar)

### DIFF
--- a/utilities/system_update.py
+++ b/utilities/system_update.py
@@ -45,29 +45,43 @@ class SystemUpdateManager:
 
             if result.returncode == 0:
                 container_info = json.loads(result.stdout)[0]
-                labels = container_info.get('Labels', {})
+                # Compose labels live under .Config.Labels in `docker inspect`,
+                # not at the top level. The original code looked at the top
+                # level, got an empty dict, and silently fell back to wrong
+                # defaults — which made the sidecar updater run against a
+                # phantom project.
+                labels = container_info.get('Config', {}).get('Labels', {}) or {}
 
-                # Extract compose project info from labels
-                project_name = labels.get('com.docker.compose.project', 'kbm20')
-                working_dir = labels.get('com.docker.compose.project.working_dir', str(self.repo_path))
-                config_files = labels.get('com.docker.compose.project.config_files', 'compose.yaml')
+                project_name = labels.get('com.docker.compose.project')
+                working_dir = labels.get('com.docker.compose.project.working_dir')
+                config_files = labels.get('com.docker.compose.project.config_files')
 
-                self._project_info = {
-                    'project_name': project_name,
-                    'working_dir': working_dir,
-                    'config_file': config_files.split(',')[0] if config_files else 'compose.yaml',
-                    'container_id': hostname
-                }
-                return self._project_info
+                if project_name and working_dir:
+                    self._project_info = {
+                        'project_name': project_name,
+                        'working_dir': working_dir,
+                        'config_file': config_files.split(',')[0] if config_files else 'compose.yaml',
+                        'container_id': hostname,
+                    }
+                    return self._project_info
+
+                print(
+                    "Warning: compose labels missing on this container "
+                    f"(project={project_name!r}, working_dir={working_dir!r}). "
+                    "Falling back to defaults — the sidecar updater may target "
+                    "the wrong project."
+                )
         except Exception as e:
             print(f"Warning: Could not auto-detect project info: {e}")
 
-        # Fallback to defaults
+        # Conservative fallback. We hardcode the known production defaults
+        # rather than self.repo_path (which is the *container* path /app —
+        # not what `docker run -v` needs on the host).
         self._project_info = {
-            'project_name': 'kbm20',
-            'working_dir': str(self.repo_path),
+            'project_name': 'kbm',
+            'working_dir': '/opt/kbm',
             'config_file': 'compose.yaml',
-            'container_id': os.environ.get('HOSTNAME', 'python-app')
+            'container_id': os.environ.get('HOSTNAME', 'python-app'),
         }
         return self._project_info
 


### PR DESCRIPTION
## What

Fix \`_get_project_info\` to read compose labels from \`.Config.Labels\` instead of the top level of \`docker inspect\` output, plus tighten the fallback path so it can't silently target a phantom project.

## Why

The labels on python-app are correct:
\`\`\`json
\"com.docker.compose.project\": \"kbm\",
\"com.docker.compose.project.working_dir\": \"/opt/kbm\"
\`\`\`

But \`container_info.get('Labels', {})\` returned \`{}\` because labels live under \`.Config.Labels\`. The code then fell back to hardcoded defaults: \`project_name='kbm20'\` (wrong) and \`working_dir=str(self.repo_path)\` = \`/app\` (the container path, which doesn't exist on the host).

The sidecar consequently ran:
\`\`\`bash
docker run -v /app:/work ... 'sh -c \"cd /work && docker compose -p kbm20 up -d\"'
\`\`\`
Docker silently created an empty \`/app\` directory on the host and mounted it. Then \`docker compose -p kbm20 up -d\` from an empty directory was a no-op (no compose.yaml, no services). The python-app restart visible in \`docker compose ps\` came from the operator's manual \`docker compose up -d\` for the smartlocks PR — not from the sidecar.

## Changes

- Read labels from \`.Config.Labels\` (the correct location).
- Require both \`project\` and \`working_dir\` labels to be present before trusting them; warn loudly otherwise.
- Fallback now uses \`project=kbm\`, \`working_dir=/opt/kbm\` (the known production values) instead of the bogus container-path defaults.

## Test plan
- [ ] Merge, manual pull on VPS, manual \`docker compose restart python-app\` once to load this fix
- [ ] Push any small change (e.g. a comment-only commit) to main
- [ ] Hit Update Now in the UI
- [ ] Restart log should now show \`Project: kbm\`, \`Working dir: /opt/kbm\`
- [ ] python-app's CREATED time in \`docker compose ps\` should refresh within ~30s of clicking Update
- [ ] The change you pushed should be live without needing manual intervention