### PR TITLE
Tenant settings page: email toggle + receipt header/footer

### DIFF
--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -33,6 +33,7 @@ from audits import audits_bp
 from smartlocks import smartlocks_bp
 from exports import exports_bp
 from search import search_bp
+from settings import settings_bp
 
 migrate_master = Migrate()
 migrate_tenant = Migrate()
@@ -101,6 +102,7 @@ def create_app():
     app.register_blueprint(exports_bp, url_prefix="/exports")
     app.register_blueprint(audits_bp, url_prefix="/audits")
     app.register_blueprint(search_bp)
+    app.register_blueprint(settings_bp, url_prefix="/settings")
 
     # 8) Debug helpers (DISABLED FOR SECURITY)
     # These routes are disabled for production security
@@ -234,10 +236,22 @@ def create_app():
         # Inject tenant information into all templates
         tenant = tenant_manager.get_current_tenant()
 
+        # Inject the tenant's settings (or None if we're not in a tenant
+        # context — root admin pages, signup, etc.) Templates can use
+        # `tenant_settings.receipt_header` etc. with safe `if` guards.
+        tenant_settings = None
+        if tenant is not None:
+            try:
+                from utilities.database import get_tenant_settings
+                tenant_settings = get_tenant_settings()
+            except Exception:
+                tenant_settings = None
+
         return dict(
             has_endpoint=has_endpoint,
             safe_url=safe_url,
             tenant=tenant,
+            tenant_settings=tenant_settings,
             is_root_domain=g.get('is_root_domain', False)
         )
 

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -1,0 +1,3 @@
+from .views import settings_bp
+
+__all__ = ["settings_bp"]

--- a/settings/views.py
+++ b/settings/views.py
@@ -1,0 +1,55 @@
+"""Per-tenant settings page.
+
+Tenant-scoped (requires a subdomain) and admin-only. Stores config in the
+tenant DB via TenantSettings.
+"""
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+from flask_login import login_required, current_user
+
+from middleware.tenant_middleware import tenant_required
+from utilities.database import get_tenant_settings
+from utilities.tenant_helpers import tenant_commit
+
+
+settings_bp = Blueprint(
+    "settings",
+    __name__,
+    template_folder="../templates",
+)
+
+
+def _require_tenant_admin():
+    """Only admins (and owners) can edit tenant settings."""
+    role = (getattr(current_user, "role", "") or "").lower()
+    if role not in {"admin", "owner"}:
+        abort(403)
+
+
+@settings_bp.get("/")
+@login_required
+@tenant_required
+def settings_page():
+    _require_tenant_admin()
+    settings = get_tenant_settings()
+    return render_template("settings.html", settings=settings)
+
+
+@settings_bp.post("/")
+@login_required
+@tenant_required
+def save_settings():
+    _require_tenant_admin()
+    settings = get_tenant_settings()
+
+    # Checkbox: present in form when checked, absent when unchecked.
+    settings.email_notifications_enabled = bool(request.form.get("email_notifications_enabled"))
+
+    # Optional free-text fields
+    header = (request.form.get("receipt_header") or "").strip()
+    footer = (request.form.get("receipt_footer") or "").strip()
+    settings.receipt_header = header or None
+    settings.receipt_footer = footer or None
+
+    tenant_commit()
+    flash("Settings saved.", "success")
+    return redirect(url_for("settings.settings_page"))

--- a/templates/base.html
+++ b/templates/base.html
@@ -984,7 +984,7 @@
                 <span class="nav-icon">🔐</span> Smart Locks
               </a>
             </div>
-            {% if current_user.is_authenticated and (current_user.role or '').lower() == 'admin' %}
+            {% if current_user.is_authenticated and (current_user.role or '').lower() in ['admin', 'owner'] %}
             <div class="nav-section">
               <div class="nav-section-label">Administration</div>
               <a href="{{ url_for('auth.list_users') }}" class="{% if request.endpoint and request.endpoint.startswith('auth.list_users') %}active{% endif %}">
@@ -992,6 +992,9 @@
               </a>
               <a href="{{ url_for('auth.activity_logs') }}" class="{% if request.endpoint == 'auth.activity_logs' %}active{% endif %}">
                 <span class="nav-icon">📋</span> Activity Logs
+              </a>
+              <a href="{{ url_for('settings.settings_page') }}" class="{% if request.endpoint and request.endpoint.startswith('settings.') %}active{% endif %}">
+                <span class="nav-icon">⚙️</span> Settings
               </a>
             </div>
             {% endif %}

--- a/templates/checkout_receipt.html
+++ b/templates/checkout_receipt.html
@@ -152,8 +152,13 @@
 
 <div class="receipt-container" id="receipt">
   <div class="receipt-header">
+    {% if tenant_settings and tenant_settings.receipt_header %}
+      <div style="margin-bottom: 16px; white-space: pre-line; font-size: 13px; color: #1f2937;">
+        {{ tenant_settings.receipt_header }}
+      </div>
+    {% endif %}
     <h1>CHECKOUT RECEIPT</h1>
-    <p>Key & Lockbox Management System</p>
+    <p>{{ tenant.company_name if tenant else 'Key & Lockbox Management System' }}</p>
     <p><strong>Receipt #{{ checkout.id }}</strong></p>
     {% if barcode_svg %}
     <div class="barcode-container" style="margin: 20px auto; text-align: center;">
@@ -280,6 +285,9 @@
   <div class="receipt-footer">
     <p>This receipt serves as proof of checkout.</p>
     <p>Please return the item(s) in good condition{% if checkout.expected_return_date %} by {{ checkout.expected_return_date.strftime('%B %d, %Y') }}{% endif %}.</p>
+    {% if tenant_settings and tenant_settings.receipt_footer %}
+    <p style="margin-top: 15px; white-space: pre-line;">{{ tenant_settings.receipt_footer }}</p>
+    {% endif %}
     <p style="margin-top: 15px; font-size: 11px;">Generated on {{ now.strftime('%B %d, %Y at %I:%M %p') }}</p>
   </div>
 </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% block title %}Settings - KBM{% endblock %}
+
+{% block head %}
+<style>
+  .settings-section + .settings-section { margin-top: 18px; }
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .checkbox-row input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-accent);
+    cursor: pointer;
+  }
+  .checkbox-row label {
+    font-size: 14px;
+    cursor: pointer;
+    margin: 0;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .field-help {
+    font-size: 13px;
+    color: var(--color-muted);
+    margin-top: 4px;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>Settings</h1>
+  <p class="muted">Tenant-wide configuration. Changes apply only to {{ tenant.company_name if tenant else 'this account' }}.</p>
+</div>
+
+<form method="post" action="{{ url_for('settings.save_settings') }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+  <div class="card settings-section">
+    <h2>Email Notifications</h2>
+    <div class="divider"></div>
+    <div class="checkbox-row">
+      <input type="checkbox" id="email_notifications_enabled" name="email_notifications_enabled"
+             {% if settings.email_notifications_enabled %}checked{% endif %}>
+      <label for="email_notifications_enabled">Send email notifications for checkouts, returns, and overdue items</label>
+    </div>
+    <p class="field-help">
+      Emails go to the contact assigned to a checkout (if their email is on file). Requires SMTP to be
+      configured at the server level — when SMTP isn't set up, this toggle has no effect.
+    </p>
+  </div>
+
+  <div class="card settings-section">
+    <h2>Receipt Header</h2>
+    <div class="divider"></div>
+    <div class="form-field">
+      <label for="receipt_header">Text to display at the top of printed checkout receipts</label>
+      <textarea id="receipt_header" name="receipt_header" rows="4"
+                placeholder="e.g. company name, address, phone, hours">{{ settings.receipt_header or '' }}</textarea>
+      <p class="field-help">Shown above the "CHECKOUT RECEIPT" title. Leave blank to omit.</p>
+    </div>
+  </div>
+
+  <div class="card settings-section">
+    <h2>Receipt Footer</h2>
+    <div class="divider"></div>
+    <div class="form-field">
+      <label for="receipt_footer">Text to display at the bottom of printed checkout receipts</label>
+      <textarea id="receipt_footer" name="receipt_footer" rows="4"
+                placeholder="e.g. return policy, contact info, thank-you message">{{ settings.receipt_footer or '' }}</textarea>
+      <p class="field-help">Shown below the standard "please return in good condition" line.</p>
+    </div>
+  </div>
+
+  <div class="toolbar spaced">
+    <button type="submit" class="btn primary">Save Changes</button>
+    <a href="{{ url_for('main.home') }}" class="btn ghost">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/utilities/database.py
+++ b/utilities/database.py
@@ -436,6 +436,57 @@ class SmartLockImage(db.Model):
         }
 
 
+class TenantSettings(db.Model):
+    """Per-tenant configuration. There's exactly one row per tenant DB.
+
+    Stored in the tenant DB (not master) so each tenant owns its own
+    settings independently. Use `get_settings()` to load — it auto-creates
+    the row on first access.
+    """
+    __tablename__ = "tenant_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    # Email notifications — when False, the notify_* helpers in
+    # utilities.email skip sending for this tenant even if SMTP is configured.
+    email_notifications_enabled = db.Column(db.Boolean, nullable=False, default=True)
+
+    # Free-text strings displayed at the top/bottom of printable receipts.
+    # Use these for company contact info, return policy, hours, etc.
+    receipt_header = db.Column(db.Text, nullable=True)
+    receipt_footer = db.Column(db.Text, nullable=True)
+
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now)
+    updated_at = db.Column(db.DateTime, nullable=False, default=utc_now, onupdate=utc_now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "email_notifications_enabled": self.email_notifications_enabled,
+            "receipt_header": self.receipt_header,
+            "receipt_footer": self.receipt_footer,
+        }
+
+
+def get_tenant_settings():
+    """Return the current tenant's TenantSettings row, creating it if missing.
+    Caller must be in a tenant request context."""
+    from utilities.tenant_helpers import tenant_query, tenant_add, tenant_commit
+
+    settings = tenant_query(TenantSettings).first()
+    if settings is None:
+        settings = TenantSettings()
+        tenant_add(settings)
+        try:
+            tenant_commit()
+        except Exception:
+            # Race-safe: if a concurrent request inserted one, fetch that.
+            from utilities.tenant_helpers import tenant_rollback
+            tenant_rollback()
+            settings = tenant_query(TenantSettings).first()
+    return settings
+
+
 class ActivityLog(db.Model):
     __tablename__ = "activity_logs"
 

--- a/utilities/email.py
+++ b/utilities/email.py
@@ -184,9 +184,23 @@ def _resolve_recipient_email(checkout) -> Optional[str]:
     return lookup_contact_email(getattr(checkout, "checked_out_to", "") or "")
 
 
+def _tenant_emails_enabled() -> bool:
+    """Check the current tenant's settings to see if email notifications
+    are turned on. Defaults to True if anything goes wrong (fail-open is
+    consistent with the previous behavior of always sending)."""
+    try:
+        from utilities.database import get_tenant_settings
+        settings = get_tenant_settings()
+        return bool(settings.email_notifications_enabled)
+    except Exception:
+        return True
+
+
 def notify_checkout(checkout, *, tenant_name: Optional[str] = None) -> bool:
     """Send a 'you've been issued an item' email for the given ItemCheckout."""
     if not is_configured():
+        return False
+    if not _tenant_emails_enabled():
         return False
     item = checkout.item
     if item is None:
@@ -219,6 +233,8 @@ def notify_checkin(checkout, *, tenant_name: Optional[str] = None) -> bool:
     """Send a 'return confirmed' email for the given ItemCheckout."""
     if not is_configured():
         return False
+    if not _tenant_emails_enabled():
+        return False
     item = checkout.item
     if item is None:
         return False
@@ -247,6 +263,8 @@ def notify_checkin(checkout, *, tenant_name: Optional[str] = None) -> bool:
 def notify_overdue(checkout, days_overdue: int, *, tenant_name: Optional[str] = None) -> bool:
     """Send an 'item is overdue' reminder for the given ItemCheckout."""
     if not is_configured():
+        return False
+    if not _tenant_emails_enabled():
         return False
     item = checkout.item
     if item is None:

--- a/utilities/tenant_schema.py
+++ b/utilities/tenant_schema.py
@@ -98,6 +98,16 @@ TENANT_UPGRADES: list[Callable] = [
         '"uploaded_at" DATETIME NOT NULL, '
         '"uploaded_by_id" INTEGER'
     ),
+    # Per-tenant settings. Singleton table (one row per tenant DB).
+    create_table_if_missing(
+        "tenant_settings",
+        '"id" INTEGER NOT NULL PRIMARY KEY, '
+        '"email_notifications_enabled" BOOLEAN NOT NULL DEFAULT 1, '
+        '"receipt_header" TEXT, '
+        '"receipt_footer" TEXT, '
+        '"created_at" DATETIME NOT NULL, '
+        '"updated_at" DATETIME NOT NULL'
+    ),
 ]
 
 


### PR DESCRIPTION
## What

First per-tenant configuration page. Three settings to start:

- **Email notifications on/off** — when off, the \`notify_*\` helpers skip sending for this tenant even when SMTP is configured at the server level.
- **Receipt header** — free-form text shown above the \"CHECKOUT RECEIPT\" title on printed receipts.
- **Receipt footer** — free-form text shown below the standard return reminder.

## How it's wired

- New \`TenantSettings\` model in the tenant DB (singleton — one row per tenant).
- \`get_tenant_settings()\` helper auto-creates the row on first access. No backfill needed.
- Idempotent table-creation migration in \`utilities/tenant_schema.py\` runs on app startup.
- New \`settings/\` blueprint at \`/settings\`. Admin-only (admin or owner role).
- Context processor injects \`tenant_settings\` into every tenant-scoped template — future templates can read settings (\`{% if tenant_settings.foo %}\`) without changing the view that renders them.
- Email helpers gain a \`_tenant_emails_enabled()\` check; fail-open if anything goes wrong (preserves current behavior on error).
- Receipt template now uses \`tenant.company_name\` in the subtitle when available (was hardcoded).

## Nav

- New \"Settings\" link in the sidebar under Administration, alongside Users and Activity Logs.
- That nav section now also shows for the \`owner\` role (was admin-only).

## Test plan
- [ ] Merge, deploy via UI updater (this is the first real exercise of the post-fix updater)
- [ ] Tenant logs show \`created table tenant_settings\` for each tenant DB on startup
- [ ] Visit \`/settings\` as an admin → form pre-populated with defaults (email enabled, header/footer empty)
- [ ] Toggle email off, save → check that a checkout to a contact-with-email no longer triggers an email send
- [ ] Set a header + footer, save → check out a key, view the receipt → both texts visible
- [ ] Visit \`/settings\` as a non-admin user → 403

## Where this lands us

This was the last of the four items you scoped: high-priority list ✅, smart locks images/fields ✅, spam fix ✅, tenant settings ✅. Plus all the updater bugs we shook out along the way.