### PR TITLE
Mount settings/ blueprint in compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -45,6 +45,7 @@ services:
       - ./main:/app/main
       - ./exports:/app/exports
       - ./search:/app/search
+      - ./settings:/app/settings
       - ./utilities:/app/utilities
       - ./middleware:/app/middleware
     networks:


### PR DESCRIPTION
## What

Add \`./settings:/app/settings\` bind mount to compose.yaml. PR #26 introduced the settings/ package but missed the mount, so the running container can't import it on restart:

\`\`\`
ModuleNotFoundError: No module named 'settings'
\`\`\`

## Why

This is exactly the trap the comment block above the mounts warns about — every new top-level Python package needs a matching mount in the same change. The image is built without the new code; bind mounts are the only path for it to reach the running container without a rebuild.

Worth thinking about: a startup assertion that imports every registered blueprint package directly and fails loud if any are import-only-from-image (i.e., no mount) — would catch this class of bug at first boot rather than after-the-fact during a restart cycle. Not in scope for this PR; flagging.

## Existing deployments

After merging:

\`\`\`bash
git pull
docker compose up -d  # picks up the new mount
\`\`\`

\`docker compose restart\` alone won't work — needs \`up -d\` to apply the mount config change.