### PR TITLE
Expand tenant settings: low-key threshold, checkout duration, per-event email toggles, overdue grace

### DIFF
--- a/audits/views.py
+++ b/audits/views.py
@@ -356,8 +356,11 @@ def delete_audit(audit_id: int):
 @login_required
 @tenant_required
 def low_copy_report():
-    """Show keys with less than 6 total copies"""
-    threshold = request.args.get("threshold", 6, type=int)
+    """Show keys below the tenant's configured low-keys threshold.
+    The threshold can be overridden for a single render via ?threshold=N."""
+    from utilities.database import get_tenant_settings
+    default_threshold = get_tenant_settings().low_keys_threshold
+    threshold = request.args.get("threshold", default_threshold, type=int)
 
     keys = (
         tenant_query(Item)

--- a/exports/views.py
+++ b/exports/views.py
@@ -430,9 +430,11 @@ def export_low_keys():
     """Export low key inventory report"""
     format_type = request.args.get("format", "csv").lower()
 
+    from utilities.database import get_tenant_settings
+    threshold = get_tenant_settings().low_keys_threshold
     keys = tenant_query(Item).filter(
         Item.type == "Key",
-        Item.total_copies < 4
+        Item.total_copies < threshold
     ).order_by(Item.total_copies.asc(), Item.label.asc()).all()
 
     data = []

--- a/main/views.py
+++ b/main/views.py
@@ -46,10 +46,12 @@ def home():
         Item.type == "Key"
     ).scalar() or 0
 
-    # Keys with less than 6 copies
+    # Keys below the tenant's configured low-keys threshold (Settings page).
+    from utilities.database import get_tenant_settings
+    low_keys_threshold = get_tenant_settings().low_keys_threshold
     keys_low_copies = session.query(Item).filter(
         Item.type == "Key",
-        Item.total_copies < 6
+        Item.total_copies < low_keys_threshold
     ).order_by(Item.total_copies.asc()).limit(10).all()
 
     # Sign stats
@@ -158,10 +160,12 @@ def reports():
         )
     ).order_by(Item.last_action_at.asc()).all()
 
-    # All keys with less than 6 copies
+    # All keys below the tenant's configured low-keys threshold.
+    from utilities.database import get_tenant_settings
+    low_keys_threshold = get_tenant_settings().low_keys_threshold
     all_keys_low = session.query(Item).filter(
         Item.type == "Key",
-        Item.total_copies < 6
+        Item.total_copies < low_keys_threshold
     ).order_by(Item.total_copies.asc()).all()
 
     # Keys with 0 available copies

--- a/settings/views.py
+++ b/settings/views.py
@@ -34,6 +34,21 @@ def settings_page():
     return render_template("settings.html", settings=settings)
 
 
+def _form_int(name: str, default: int, *, minimum: int = 0, maximum: int | None = None) -> int:
+    """Parse a form value as int, clamped to [minimum, maximum]. Falls back
+    to `default` on missing / invalid input so a typo can't break the page."""
+    raw = (request.form.get(name) or "").strip()
+    try:
+        value = int(raw) if raw else default
+    except ValueError:
+        value = default
+    if value < minimum:
+        value = minimum
+    if maximum is not None and value > maximum:
+        value = maximum
+    return value
+
+
 @settings_bp.post("/")
 @login_required
 @tenant_required
@@ -41,8 +56,17 @@ def save_settings():
     _require_tenant_admin()
     settings = get_tenant_settings()
 
-    # Checkbox: present in form when checked, absent when unchecked.
+    # Email — master switch + per-event flags. Unchecked checkboxes don't
+    # appear in form data, so we read each as truthy/false from presence.
     settings.email_notifications_enabled = bool(request.form.get("email_notifications_enabled"))
+    settings.notify_on_checkout = bool(request.form.get("notify_on_checkout"))
+    settings.notify_on_checkin = bool(request.form.get("notify_on_checkin"))
+    settings.notify_on_overdue = bool(request.form.get("notify_on_overdue"))
+
+    # Numeric thresholds (clamped to sane ranges so a typo can't crash queries).
+    settings.overdue_grace_days = _form_int("overdue_grace_days", default=0, minimum=0, maximum=365)
+    settings.low_keys_threshold = _form_int("low_keys_threshold", default=4, minimum=0, maximum=999)
+    settings.default_checkout_days = _form_int("default_checkout_days", default=7, minimum=0, maximum=365)
 
     # Optional free-text fields
     header = (request.form.get("receipt_header") or "").strip()

--- a/templates/keys.html
+++ b/templates/keys.html
@@ -446,6 +446,24 @@
 <script>
   const statusOptions = {{ status_options_lower | tojson }};
 
+  // Tenant's configured default checkout duration. Pulled from tenant_settings
+  // via the global context processor — falls back to 7 if no settings row
+  // (which only happens before the first /settings visit creates one).
+  const DEFAULT_CHECKOUT_DAYS = {{ tenant_settings.default_checkout_days if tenant_settings else 7 }};
+
+  /** Return today + DEFAULT_CHECKOUT_DAYS as a YYYY-MM-DD string suitable for
+   *  pre-filling <input type="date">. Returns '' (blank field) when the
+   *  setting is 0. */
+  function defaultReturnDate() {
+    if (!DEFAULT_CHECKOUT_DAYS || DEFAULT_CHECKOUT_DAYS <= 0) return '';
+    const d = new Date();
+    d.setDate(d.getDate() + DEFAULT_CHECKOUT_DAYS);
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  }
+
   function submitAction(url, payload) {
     const form = document.createElement('form');
     form.method = 'post';
@@ -675,7 +693,7 @@
       openModal('checkout', [
         { name: 'copies', label: 'Number of Copies', type: 'number', required: true, defaultValue: '1', help: `${available} copies available` },
         { name: 'purpose', label: 'Purpose', placeholder: 'Optional' },
-        { name: 'expected_return_date', label: 'Expected Return Date', type: 'date', placeholder: 'Optional' },
+        { name: 'expected_return_date', label: 'Expected Return Date', type: 'date', placeholder: 'Optional', defaultValue: defaultReturnDate() },
       ], (formData) => {
         const copies = parseInt(formData.get('copies')) || 0;
         if (copies < 1 || copies > available) {
@@ -819,7 +837,7 @@
         { name: 'copies', label: 'Number of Copies', type: 'number', required: true, defaultValue: '1', help: `${available} copies available` },
         { name: 'assigned_to', label: 'Assigned To', placeholder: 'Start typing to search contacts...', autocomplete: 'contacts' },
         { name: 'assignment_type', label: 'Assignment Type', widget: 'select', required: true, options: ['tenant', 'contractor', 'property'] },
-        { name: 'expected_return_date', label: 'Expected Return Date (Contractors)', type: 'date', placeholder: 'Required for contractors' },
+        { name: 'expected_return_date', label: 'Expected Return Date (Contractors)', type: 'date', placeholder: 'Required for contractors', defaultValue: defaultReturnDate() },
         { name: 'property_id', label: 'Property', widget: 'select', options: propertyOptions, defaultValue: defaultPropertyId, help: 'Only required when assignment type is Property' },
         { name: 'property_unit_id', label: 'Property Unit', widget: 'select', options: defaultUnitOptions, defaultValue: defaultPropertyUnitId },
       ], (formData) => {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -8,6 +8,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    margin-bottom: 8px;
   }
   .checkbox-row input[type="checkbox"] {
     width: 18px;
@@ -27,6 +28,15 @@
     color: var(--color-muted);
     margin-top: 4px;
   }
+  .number-field input[type="number"] {
+    max-width: 140px;
+  }
+  .sub-checkboxes {
+    margin-top: 10px;
+    margin-left: 28px;
+    padding-left: 12px;
+    border-left: 2px solid var(--color-border);
+  }
 </style>
 {% endblock %}
 
@@ -39,36 +49,111 @@
 <form method="post" action="{{ url_for('settings.save_settings') }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
+  <!-- ============================================================ -->
+  <!-- Inventory                                                    -->
+  <!-- ============================================================ -->
+  <div class="card settings-section">
+    <h2>Inventory</h2>
+    <div class="divider"></div>
+
+    <div class="form-field number-field">
+      <label for="low_keys_threshold">Low-key threshold</label>
+      <input type="number" id="low_keys_threshold" name="low_keys_threshold"
+             min="0" max="999" step="1"
+             value="{{ settings.low_keys_threshold }}">
+      <p class="field-help">
+        Keys with fewer than this many total copies show up in the "low keys"
+        report and dashboard widgets. Common values: 3 (urgent only) to 6
+        (early warning).
+      </p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- Checkouts & returns                                          -->
+  <!-- ============================================================ -->
+  <div class="card settings-section">
+    <h2>Checkouts &amp; Returns</h2>
+    <div class="divider"></div>
+
+    <div class="form-field number-field">
+      <label for="default_checkout_days">Default checkout duration (days)</label>
+      <input type="number" id="default_checkout_days" name="default_checkout_days"
+             min="0" max="365" step="1"
+             value="{{ settings.default_checkout_days }}">
+      <p class="field-help">
+        When checking out or assigning a key, the "expected return" field is
+        pre-filled with today + this many days. Set to 0 to leave it blank.
+      </p>
+    </div>
+
+    <div class="form-field number-field" style="margin-top: 14px;">
+      <label for="overdue_grace_days">Overdue reminder grace period (days)</label>
+      <input type="number" id="overdue_grace_days" name="overdue_grace_days"
+             min="0" max="365" step="1"
+             value="{{ settings.overdue_grace_days }}">
+      <p class="field-help">
+        Wait this many days after the expected return date before sending the
+        first overdue reminder email. 0 = remind starting the day after due.
+      </p>
+    </div>
+  </div>
+
+  <!-- ============================================================ -->
+  <!-- Email notifications                                          -->
+  <!-- ============================================================ -->
   <div class="card settings-section">
     <h2>Email Notifications</h2>
     <div class="divider"></div>
+
     <div class="checkbox-row">
       <input type="checkbox" id="email_notifications_enabled" name="email_notifications_enabled"
              {% if settings.email_notifications_enabled %}checked{% endif %}>
-      <label for="email_notifications_enabled">Send email notifications for checkouts, returns, and overdue items</label>
+      <label for="email_notifications_enabled">
+        <strong>Master switch:</strong> send any email notifications at all
+      </label>
     </div>
     <p class="field-help">
-      Emails go to the contact assigned to a checkout (if their email is on file). Requires SMTP to be
-      configured at the server level — when SMTP isn't set up, this toggle has no effect.
+      When off, no emails are sent regardless of the per-event toggles below.
+      Requires SMTP to be configured at the server level — when SMTP isn't set
+      up, none of these have any effect.
     </p>
-  </div>
 
-  <div class="card settings-section">
-    <h2>Receipt Header</h2>
-    <div class="divider"></div>
-    <div class="form-field">
-      <label for="receipt_header">Text to display at the top of printed checkout receipts</label>
-      <textarea id="receipt_header" name="receipt_header" rows="4"
-                placeholder="e.g. company name, address, phone, hours">{{ settings.receipt_header or '' }}</textarea>
-      <p class="field-help">Shown above the "CHECKOUT RECEIPT" title. Leave blank to omit.</p>
+    <div class="sub-checkboxes">
+      <div class="checkbox-row">
+        <input type="checkbox" id="notify_on_checkout" name="notify_on_checkout"
+               {% if settings.notify_on_checkout %}checked{% endif %}>
+        <label for="notify_on_checkout">Send "item issued" emails on checkout / assign</label>
+      </div>
+      <div class="checkbox-row">
+        <input type="checkbox" id="notify_on_checkin" name="notify_on_checkin"
+               {% if settings.notify_on_checkin %}checked{% endif %}>
+        <label for="notify_on_checkin">Send "return confirmed" emails on check-in</label>
+      </div>
+      <div class="checkbox-row">
+        <input type="checkbox" id="notify_on_overdue" name="notify_on_overdue"
+               {% if settings.notify_on_overdue %}checked{% endif %}>
+        <label for="notify_on_overdue">Send overdue reminders (daily cron)</label>
+      </div>
     </div>
   </div>
 
+  <!-- ============================================================ -->
+  <!-- Receipts                                                     -->
+  <!-- ============================================================ -->
   <div class="card settings-section">
-    <h2>Receipt Footer</h2>
+    <h2>Receipts</h2>
     <div class="divider"></div>
+
     <div class="form-field">
-      <label for="receipt_footer">Text to display at the bottom of printed checkout receipts</label>
+      <label for="receipt_header">Receipt Header</label>
+      <textarea id="receipt_header" name="receipt_header" rows="4"
+                placeholder="e.g. company name, address, phone, hours">{{ settings.receipt_header or '' }}</textarea>
+      <p class="field-help">Shown above the "CHECKOUT RECEIPT" title on printed receipts. Leave blank to omit.</p>
+    </div>
+
+    <div class="form-field" style="margin-top: 14px;">
+      <label for="receipt_footer">Receipt Footer</label>
       <textarea id="receipt_footer" name="receipt_footer" rows="4"
                 placeholder="e.g. return policy, contact info, thank-you message">{{ settings.receipt_footer or '' }}</textarea>
       <p class="field-help">Shown below the standard "please return in good condition" line.</p>

--- a/utilities/database.py
+++ b/utilities/database.py
@@ -447,9 +447,26 @@ class TenantSettings(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
 
-    # Email notifications — when False, the notify_* helpers in
-    # utilities.email skip sending for this tenant even if SMTP is configured.
+    # Email notifications — master switch. When False, the notify_* helpers
+    # in utilities.email skip sending for this tenant even if SMTP is
+    # configured. Per-event flags below give finer control.
     email_notifications_enabled = db.Column(db.Boolean, nullable=False, default=True)
+    notify_on_checkout = db.Column(db.Boolean, nullable=False, default=True)
+    notify_on_checkin = db.Column(db.Boolean, nullable=False, default=True)
+    notify_on_overdue = db.Column(db.Boolean, nullable=False, default=True)
+
+    # Days past expected_return_date before the daily overdue cron sends
+    # the first reminder. Default 0 = remind starting the day after due.
+    overdue_grace_days = db.Column(db.Integer, nullable=False, default=0)
+
+    # Threshold for the "low keys" reports/dashboard widgets — keys with
+    # fewer than this many total copies are flagged.
+    low_keys_threshold = db.Column(db.Integer, nullable=False, default=4)
+
+    # When checking out / assigning a key, the form's "expected return"
+    # field gets pre-filled with today + this many days. Set to 0 to leave
+    # the field blank by default.
+    default_checkout_days = db.Column(db.Integer, nullable=False, default=7)
 
     # Free-text strings displayed at the top/bottom of printable receipts.
     # Use these for company contact info, return policy, hours, etc.
@@ -463,6 +480,12 @@ class TenantSettings(db.Model):
         return {
             "id": self.id,
             "email_notifications_enabled": self.email_notifications_enabled,
+            "notify_on_checkout": self.notify_on_checkout,
+            "notify_on_checkin": self.notify_on_checkin,
+            "notify_on_overdue": self.notify_on_overdue,
+            "overdue_grace_days": self.overdue_grace_days,
+            "low_keys_threshold": self.low_keys_threshold,
+            "default_checkout_days": self.default_checkout_days,
             "receipt_header": self.receipt_header,
             "receipt_footer": self.receipt_footer,
         }

--- a/utilities/email.py
+++ b/utilities/email.py
@@ -184,14 +184,26 @@ def _resolve_recipient_email(checkout) -> Optional[str]:
     return lookup_contact_email(getattr(checkout, "checked_out_to", "") or "")
 
 
-def _tenant_emails_enabled() -> bool:
+def _tenant_emails_enabled(event: Optional[str] = None) -> bool:
     """Check the current tenant's settings to see if email notifications
-    are turned on. Defaults to True if anything goes wrong (fail-open is
-    consistent with the previous behavior of always sending)."""
+    are turned on, optionally for a specific event ('checkout' / 'checkin'
+    / 'overdue').
+
+    Both the master switch (`email_notifications_enabled`) AND the per-event
+    flag (`notify_on_<event>`) must be true to send. Defaults to True on any
+    error so a settings-table problem doesn't silently kill emails."""
     try:
         from utilities.database import get_tenant_settings
         settings = get_tenant_settings()
-        return bool(settings.email_notifications_enabled)
+        if not settings.email_notifications_enabled:
+            return False
+        if event == "checkout":
+            return bool(settings.notify_on_checkout)
+        if event == "checkin":
+            return bool(settings.notify_on_checkin)
+        if event == "overdue":
+            return bool(settings.notify_on_overdue)
+        return True
     except Exception:
         return True
 
@@ -200,7 +212,7 @@ def notify_checkout(checkout, *, tenant_name: Optional[str] = None) -> bool:
     """Send a 'you've been issued an item' email for the given ItemCheckout."""
     if not is_configured():
         return False
-    if not _tenant_emails_enabled():
+    if not _tenant_emails_enabled("checkout"):
         return False
     item = checkout.item
     if item is None:
@@ -233,7 +245,7 @@ def notify_checkin(checkout, *, tenant_name: Optional[str] = None) -> bool:
     """Send a 'return confirmed' email for the given ItemCheckout."""
     if not is_configured():
         return False
-    if not _tenant_emails_enabled():
+    if not _tenant_emails_enabled("checkin"):
         return False
     item = checkout.item
     if item is None:
@@ -264,7 +276,7 @@ def notify_overdue(checkout, days_overdue: int, *, tenant_name: Optional[str] = 
     """Send an 'item is overdue' reminder for the given ItemCheckout."""
     if not is_configured():
         return False
-    if not _tenant_emails_enabled():
+    if not _tenant_emails_enabled("overdue"):
         return False
     item = checkout.item
     if item is None:

--- a/utilities/send_overdue_reminders.py
+++ b/utilities/send_overdue_reminders.py
@@ -22,11 +22,13 @@ from datetime import datetime
 import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from datetime import timedelta  # noqa: E402
+
 from app_multitenant import create_app  # noqa: E402
 from utilities.master_database import Account  # noqa: E402
 from utilities.tenant_manager import tenant_manager  # noqa: E402
 from utilities.tenant_helpers import tenant_query  # noqa: E402
-from utilities.database import ItemCheckout  # noqa: E402
+from utilities.database import ItemCheckout, get_tenant_settings  # noqa: E402
 from utilities.email import is_configured, notify_overdue  # noqa: E402
 
 log = logging.getLogger("kbm.overdue")
@@ -50,12 +52,17 @@ def run_for_tenant(account: Account) -> tuple[int, int]:
         log.warning("Skipping %s: tenant DB file missing", account.subdomain)
         return 0, 0
 
+    # Apply the tenant's overdue grace period so we don't pester people the
+    # day after their expected return. Default 0 = remind starting day after.
+    grace_days = max(0, get_tenant_settings().overdue_grace_days or 0)
+    cutoff = now - timedelta(days=grace_days)
+
     overdue = (
         tenant_query(ItemCheckout)
         .filter(
             ItemCheckout.is_active.is_(True),
             ItemCheckout.expected_return_date.isnot(None),
-            ItemCheckout.expected_return_date < now,
+            ItemCheckout.expected_return_date < cutoff,
         )
         .all()
     )

--- a/utilities/tenant_schema.py
+++ b/utilities/tenant_schema.py
@@ -108,6 +108,15 @@ TENANT_UPGRADES: list[Callable] = [
         '"created_at" DATETIME NOT NULL, '
         '"updated_at" DATETIME NOT NULL'
     ),
+    # Expanded settings columns added after the table was originally
+    # created. Per-event email flags + a few numeric thresholds that
+    # used to be hardcoded.
+    add_column_if_missing("tenant_settings", "notify_on_checkout", "BOOLEAN NOT NULL DEFAULT 1"),
+    add_column_if_missing("tenant_settings", "notify_on_checkin", "BOOLEAN NOT NULL DEFAULT 1"),
+    add_column_if_missing("tenant_settings", "notify_on_overdue", "BOOLEAN NOT NULL DEFAULT 1"),
+    add_column_if_missing("tenant_settings", "overdue_grace_days", "INTEGER NOT NULL DEFAULT 0"),
+    add_column_if_missing("tenant_settings", "low_keys_threshold", "INTEGER NOT NULL DEFAULT 4"),
+    add_column_if_missing("tenant_settings", "default_checkout_days", "INTEGER NOT NULL DEFAULT 7"),
 ]
 
 


### PR DESCRIPTION
## What

Six previously-hardcoded values are now tenant-configurable on the Settings page.

| Setting | Default | What it does |
|---|---|---|
| \`low_keys_threshold\` | 4 | Keys with fewer total copies than this show up in the low-keys report + dashboard widgets. |
| \`default_checkout_days\` | 7 | Pre-fills the "Expected Return Date" field on key checkout/assign with today + N. 0 = blank. |
| \`notify_on_checkout\` | true | Per-event email gate (master \`email_notifications_enabled\` must also be on). |
| \`notify_on_checkin\` | true | Same. |
| \`notify_on_overdue\` | true | Same. |
| \`overdue_grace_days\` | 0 | Daily overdue cron waits this many days past the expected return before sending the first reminder. |

## Why

You asked. Plus most of these were inconsistently hardcoded — \`low_keys\` was 4 in \`exports\`, 6 in \`main.home\` + \`main.reports\` + \`audits\`. Now unified.

## Code touched

- \`utilities/database.py\` — six new columns on \`TenantSettings\`.
- \`utilities/tenant_schema.py\` — idempotent \`add_column_if_missing\` migrations for each.
- \`settings/views.py\` — POST handler reads & clamps the new values.
- \`templates/settings.html\` — reorganized into Inventory / Checkouts & Returns / Email / Receipts sections with help text per field.
- \`main/views.py\`, \`exports/views.py\`, \`audits/views.py\` — three call sites for the low-keys threshold all read from settings.
- \`templates/keys.html\` — checkout + assign modals pre-fill \`expected_return_date\` via a new \`defaultReturnDate()\` JS helper that uses the tenant's \`default_checkout_days\` from the global \`tenant_settings\` context var.
- \`utilities/email.py\` — \`_tenant_emails_enabled\` now takes an event name; both the master switch and the per-event flag must be true.
- \`utilities/send_overdue_reminders.py\` — applies the grace period to the overdue query cutoff.

## Defaults match prior behavior

No observable change for any tenant that hasn't visited /settings yet — the new columns default to values that match how the app behaved before. Numeric inputs are server-side clamped so a typo can't break later queries.

## Deploy
Standard: merge → in-app updater → tenant migrations run on startup, log line per tenant DB will show \`added column tenant_settings.low_keys_threshold\` etc.

## Test plan
- [ ] Visit /settings as admin → see the four new sections with all fields populated at defaults
- [ ] Set low_keys_threshold to 10, save, visit /reports → key list now uses 10
- [ ] Set default_checkout_days to 14, do a key checkout → "Expected Return Date" pre-filled with today + 14
- [ ] Turn off notify_on_overdue (keep master on), run \`python -m utilities.send_overdue_reminders\` → no email even with overdue items
- [ ] Set overdue_grace_days to 3, ensure runner skips items <3 days overdue