### PR TITLE
UX polish: toasts, themed error pages, empty states, mobile toolbars

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -1,17 +1,24 @@
 {% extends "base.html" %}
 
-{% block title %}403 - Forbidden{% endblock %}
+{% block title %}403 — Forbidden{% endblock %}
 
 {% block content %}
-<div class="max-w-2xl mx-auto text-center py-16">
-    <h1 class="text-6xl font-bold text-gray-800 mb-4">403</h1>
-    <h2 class="text-2xl font-semibold text-gray-700 mb-4">Access Forbidden</h2>
-    <p class="text-gray-600 mb-8">
-        {{ error.description or "You don't have permission to access this resource." }}
+<div class="form-shell" style="text-align: center; padding: 40px 20px;">
+  <div class="card" style="padding: 48px 32px;">
+    <div style="font-size: 72px; font-weight: 700; color: var(--color-accent); line-height: 1; margin-bottom: 8px;">
+      403
+    </div>
+    <h1 style="margin: 0 0 12px;">Access Forbidden</h1>
+    <p class="muted" style="font-size: 15px; margin: 0 auto 24px; max-width: 420px;">
+      {{ error.description if error and error.description else "You don't have permission to access this resource." }}
     </p>
-    <a href="{{ url_for('main.home') if not g.is_root_domain else url_for('index') }}"
-       class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+    <div class="toolbar" style="justify-content: center;">
+      <a class="btn primary"
+         href="{{ url_for('main.home') if not is_root_domain else url_for('index') }}">
         Go Home
-    </a>
+      </a>
+      <a class="btn ghost" href="javascript:history.back()">Go Back</a>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,17 +1,24 @@
 {% extends "base.html" %}
 
-{% block title %}404 - Not Found{% endblock %}
+{% block title %}404 — Not Found{% endblock %}
 
 {% block content %}
-<div class="max-w-2xl mx-auto text-center py-16">
-    <h1 class="text-6xl font-bold text-gray-800 mb-4">404</h1>
-    <h2 class="text-2xl font-semibold text-gray-700 mb-4">Page Not Found</h2>
-    <p class="text-gray-600 mb-8">
-        {{ error.description or "The page you're looking for doesn't exist." }}
+<div class="form-shell" style="text-align: center; padding: 40px 20px;">
+  <div class="card" style="padding: 48px 32px;">
+    <div style="font-size: 72px; font-weight: 700; color: var(--color-accent); line-height: 1; margin-bottom: 8px;">
+      404
+    </div>
+    <h1 style="margin: 0 0 12px;">Page Not Found</h1>
+    <p class="muted" style="font-size: 15px; margin: 0 auto 24px; max-width: 420px;">
+      {{ error.description if error and error.description else "The page you're looking for doesn't exist." }}
     </p>
-    <a href="{{ url_for('main.home') if not g.is_root_domain else url_for('index') }}"
-       class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+    <div class="toolbar" style="justify-content: center;">
+      <a class="btn primary"
+         href="{{ url_for('main.home') if not is_root_domain else url_for('index') }}">
         Go Home
-    </a>
+      </a>
+      <a class="btn ghost" href="javascript:history.back()">Go Back</a>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,80 +1,25 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Something went wrong - KBM</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      :root {
-        color-scheme: dark;
-        --accent: #e53935;
-        --bg: radial-gradient(circle at top, #1f2024 0%, #0d0e12 55%, #05060a 100%);
-        --panel: rgba(17, 24, 39, 0.82);
-        --text: #f8fafc;
-        --muted: #9ca3af;
-      }
+{% extends "base.html" %}
 
-      * { box-sizing: border-box; }
+{% block title %}500 — Server Error{% endblock %}
 
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 40px 20px;
-        background: var(--bg);
-        font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-        color: var(--text);
-      }
-
-      .shell {
-        width: min(420px, 100%);
-        background: var(--panel);
-        border-radius: 20px;
-        padding: 36px 32px;
-        border: 1px solid rgba(229, 57, 53, 0.25);
-        box-shadow: 0 24px 60px rgba(229, 57, 53, 0.18);
-        text-align: center;
-        backdrop-filter: blur(12px);
-      }
-
-      h1 {
-        margin: 0 0 12px;
-        font-size: 26px;
-        font-weight: 600;
-      }
-
-      p {
-        margin: 0 0 24px;
-        color: var(--muted);
-        font-size: 15px;
-        line-height: 1.6;
-      }
-
-      a {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 12px 18px;
-        border-radius: 12px;
-        background: linear-gradient(135deg, #f87171 0%, var(--accent) 90%);
-        color: #fff;
-        text-decoration: none;
-        font-weight: 600;
-        box-shadow: 0 18px 30px rgba(229, 57, 53, 0.22);
-      }
-
-      a:hover {
-        transform: translateY(-1px);
-      }
-    </style>
-  </head>
-  <body>
-    <div class="shell">
-      <h1>Something went wrong</h1>
-      <p>We couldn't complete that action. Please try again in a moment.</p>
-      <a href="{{ url_for('main.home') }}">Return to Home</a>
+{% block content %}
+<div class="form-shell" style="text-align: center; padding: 40px 20px;">
+  <div class="card" style="padding: 48px 32px;">
+    <div style="font-size: 72px; font-weight: 700; color: var(--color-accent); line-height: 1; margin-bottom: 8px;">
+      500
     </div>
-  </body>
-</html>
+    <h1 style="margin: 0 0 12px;">Something went wrong</h1>
+    <p class="muted" style="font-size: 15px; margin: 0 auto 24px; max-width: 420px;">
+      {{ error.description if error and error.description else
+         "We couldn't complete that action. Please try again in a moment — if it keeps happening, contact your administrator." }}
+    </p>
+    <div class="toolbar" style="justify-content: center;">
+      <a class="btn primary"
+         href="{{ url_for('main.home') if not is_root_domain else url_for('index') }}">
+        Go Home
+      </a>
+      <a class="btn ghost" href="javascript:location.reload()">Try Again</a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -387,6 +387,16 @@
 
       @media (max-width: 720px) {
         .global-search { width: 180px; }
+
+        /* Stack toolbar buttons + searchbars vertically on small screens
+           so they don't overflow the page or get awkwardly wrapped. */
+        .toolbar { flex-direction: column; align-items: stretch; }
+        .toolbar > .btn,
+        .toolbar > a.btn,
+        .toolbar > button.btn { width: 100%; justify-content: center; }
+        .searchbar { width: 100%; }
+        .searchbar input { min-width: 0; flex: 1; }
+        .page-header { gap: 10px; }
       }
 
       .btn {
@@ -699,6 +709,8 @@
         margin-bottom: 20px;
       }
 
+      /* Default flash style is the "error" / red treatment, since that's the
+         most common case (validation errors, etc.). Categories override. */
       .flash {
         padding: 14px 16px;
         border-radius: 12px;
@@ -706,30 +718,107 @@
         background: rgba(229, 57, 53, 0.1);
         color: #ffb4b4;
         font-size: 14px;
+        animation: flash-fade-in 0.2s ease;
       }
-
+      .flash.error {
+        border-color: rgba(239, 68, 68, 0.35);
+        background: rgba(239, 68, 68, 0.12);
+        color: #fecaca;
+      }
+      body.light .flash.error,
+      body.light .flash:not(.success):not(.info):not(.warning) {
+        border-color: rgba(185, 28, 28, 0.4);
+        background: rgba(254, 226, 226, 0.9);
+        color: #991b1b;
+      }
+      .flash.warning {
+        border-color: rgba(251, 191, 36, 0.35);
+        background: rgba(251, 191, 36, 0.12);
+        color: #fde68a;
+      }
+      body.light .flash.warning {
+        border-color: rgba(180, 83, 9, 0.4);
+        background: rgba(254, 243, 199, 0.9);
+        color: #92400e;
+      }
       .flash.success {
         border-color: rgba(74, 222, 128, 0.25);
         background: rgba(34, 197, 94, 0.12);
         color: #86efac;
       }
-
       body.light .flash.success {
         border-color: rgba(21, 128, 61, 0.3);
         background: rgba(21, 128, 61, 0.15);
         color: #15803d;
       }
-
       .flash.info {
         border-color: rgba(14, 165, 233, 0.25);
         background: rgba(14, 165, 233, 0.12);
         color: #7dd3fc;
       }
-
       body.light .flash.info {
         border-color: rgba(14, 116, 183, 0.3);
         background: rgba(14, 116, 183, 0.15);
         color: #0e74b7;
+      }
+      .flash.is-dismissing {
+        animation: flash-fade-out 0.4s ease forwards;
+      }
+      @keyframes flash-fade-in {
+        from { opacity: 0; transform: translateY(-6px); }
+        to   { opacity: 1; transform: translateY(0); }
+      }
+      @keyframes flash-fade-out {
+        to { opacity: 0; transform: translateY(-6px); height: 0; padding-top: 0; padding-bottom: 0; margin: 0; border-width: 0; }
+      }
+
+      /* ------------------------------------------------------------ */
+      /*  Toast system — non-blocking, themed alternative to alert()   */
+      /* ------------------------------------------------------------ */
+      .toast-host {
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        z-index: 200;
+        pointer-events: none;
+      }
+      .toast {
+        pointer-events: auto;
+        min-width: 240px;
+        max-width: 360px;
+        padding: 12px 14px;
+        border-radius: 10px;
+        font-size: 14px;
+        font-weight: 500;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+        border: 1px solid var(--color-border);
+        background: var(--color-card);
+        color: var(--color-text);
+        animation: toast-in 0.18s ease;
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+      }
+      .toast .toast-icon { font-size: 16px; line-height: 1.2; }
+      .toast .toast-msg  { flex: 1; }
+      .toast.is-dismissing { animation: toast-out 0.25s ease forwards; }
+      .toast.success { border-color: rgba(34, 197, 94, 0.45); }
+      .toast.success .toast-icon { color: #4ade80; }
+      .toast.error   { border-color: rgba(239, 68, 68, 0.45); }
+      .toast.error   .toast-icon { color: #f87171; }
+      .toast.warning { border-color: rgba(251, 191, 36, 0.45); }
+      .toast.warning .toast-icon { color: #fbbf24; }
+      .toast.info    { border-color: rgba(14, 165, 233, 0.45); }
+      .toast.info    .toast-icon { color: #38bdf8; }
+      @keyframes toast-in {
+        from { opacity: 0; transform: translateX(20px); }
+        to   { opacity: 1; transform: translateX(0); }
+      }
+      @keyframes toast-out {
+        to { opacity: 0; transform: translateX(20px); }
       }
 
       .empty-state {
@@ -740,6 +829,9 @@
         border-radius: 16px;
         background: rgba(148, 163, 184, 0.04);
       }
+      .empty-state h3 { margin: 0 0 6px; font-size: 16px; color: var(--color-text); }
+      .empty-state p  { margin: 0 0 14px; }
+      .empty-state .toolbar { justify-content: center; }
 
       /* Modal System */
       .modal-root {
@@ -1059,6 +1151,9 @@
       </div>
     </div>
 
+    <!-- Toast host — populated dynamically via window.toast() -->
+    <div class="toast-host" id="toast-host" aria-live="polite" aria-atomic="true"></div>
+
     <!-- Receipt Print Modal -->
     <div class="modal-root" id="receipt-modal">
       <div class="modal-backdrop" onclick="closeReceiptModal()"></div>
@@ -1140,6 +1235,74 @@
           showReceiptModal(receiptIdParam);
         }
       });
+
+      // ----------------------------------------------------------------
+      //  Toast helper + flash auto-dismiss
+      // ----------------------------------------------------------------
+      // Usage from any template:
+      //   toast('Saved');                       // info, default
+      //   toast('Saved', { type: 'success' });  // success / error / warning / info
+      //   toast('Heads up', { duration: 8000 });
+      //
+      // Designed as a non-blocking alternative to alert() — same one-call
+      // ergonomics, doesn't pause the page, themed.
+      (function () {
+        const TOAST_ICONS = { success: '✓', error: '✕', warning: '!', info: 'i' };
+        const host = function () { return document.getElementById('toast-host'); };
+
+        function dismiss(el) {
+          if (!el || el.classList.contains('is-dismissing')) return;
+          el.classList.add('is-dismissing');
+          el.addEventListener('animationend', () => el.remove(), { once: true });
+        }
+
+        window.toast = function (message, opts) {
+          opts = opts || {};
+          const type = opts.type || 'info';
+          const duration = opts.duration === 0 ? 0 : (opts.duration || 4500);
+          const root = host();
+          if (!root) { return; }
+          const el = document.createElement('div');
+          el.className = `toast ${type}`;
+          el.setAttribute('role', type === 'error' ? 'alert' : 'status');
+          const icon = document.createElement('span');
+          icon.className = 'toast-icon';
+          icon.textContent = TOAST_ICONS[type] || '•';
+          const text = document.createElement('span');
+          text.className = 'toast-msg';
+          text.textContent = message;
+          el.appendChild(icon);
+          el.appendChild(text);
+          el.addEventListener('click', () => dismiss(el));
+          root.appendChild(el);
+          if (duration > 0) {
+            setTimeout(() => dismiss(el), duration);
+          }
+          return el;
+        };
+
+        // Server-rendered flash messages auto-dismiss after 6s. Click to
+        // dismiss earlier. Errors stick around longer (12s) since they
+        // usually carry actionable info.
+        function autoDismissFlashes() {
+          document.querySelectorAll('.flash-container .flash').forEach((flash) => {
+            const isError = flash.classList.contains('error') ||
+                            (!flash.classList.contains('success') &&
+                             !flash.classList.contains('info') &&
+                             !flash.classList.contains('warning'));
+            const ttl = isError ? 12000 : 6000;
+            flash.style.cursor = 'pointer';
+            flash.title = 'Click to dismiss';
+            flash.addEventListener('click', () => dismiss(flash));
+            setTimeout(() => dismiss(flash), ttl);
+          });
+        }
+        if (document.readyState === 'loading') {
+          window.addEventListener('DOMContentLoaded', autoDismissFlashes);
+        } else {
+          autoDismissFlashes();
+        }
+      })();
 
       // ---- Global search autocomplete ----
       (function () {

--- a/templates/base.html
+++ b/templates/base.html
@@ -602,6 +602,85 @@
         color: var(--color-danger);
       }
 
+      /* Item status colors — distinct per state so "assigned" doesn't read
+         the same as "available" at a glance. Class is derived from the
+         status string (lowercase, underscores -> dashes), e.g.
+         `status-available`, `status-checked-out`, `status-maintenance`. */
+      .tag.status-available {
+        background: rgba(74, 222, 128, 0.18);
+        color: #4ade80;
+      }
+      body.light .tag.status-available {
+        background: rgba(21, 128, 61, 0.15);
+        color: #15803d;
+      }
+      .tag.status-assigned {
+        background: rgba(56, 189, 248, 0.18);
+        color: #38bdf8;
+      }
+      body.light .tag.status-assigned {
+        background: rgba(2, 132, 199, 0.15);
+        color: #075985;
+      }
+      .tag.status-checked-out {
+        background: rgba(251, 191, 36, 0.20);
+        color: #fbbf24;
+      }
+      body.light .tag.status-checked-out {
+        background: rgba(180, 83, 9, 0.15);
+        color: #92400e;
+      }
+      .tag.status-maintenance {
+        background: rgba(168, 85, 247, 0.18);
+        color: #c084fc;
+      }
+      body.light .tag.status-maintenance {
+        background: rgba(126, 34, 206, 0.15);
+        color: #6b21a8;
+      }
+      .tag.status-retired {
+        background: rgba(148, 163, 184, 0.18);
+        color: var(--color-muted);
+        text-decoration: line-through;
+        text-decoration-thickness: 1px;
+      }
+
+      /* Attention indicators independent of status. Use these to flag a
+         number/value that needs attention (e.g. keys whose total copies
+         are below the tenant's low-keys threshold). They're meant to wrap
+         a count or inline value, not a status word. */
+      .tag.low-stock {
+        background: rgba(239, 68, 68, 0.18);
+        color: #f87171;
+      }
+      body.light .tag.low-stock {
+        background: rgba(185, 28, 28, 0.15);
+        color: #991b1b;
+      }
+      .num-low-stock {
+        color: #f87171;
+        font-weight: 700;
+      }
+      body.light .num-low-stock {
+        color: #b91c1c;
+      }
+      /* Small inline red indicator for "this row needs attention". Use as
+            <span class="low-dot" title="Total copies below threshold"></span>
+         next to the label or count. The browser-native title tooltip is
+         enough — no JS, no extra layout. */
+      .low-dot {
+        display: inline-block;
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: #ef4444;
+        margin-left: 6px;
+        vertical-align: middle;
+        cursor: help;
+        box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.18);
+      }
+      body.light .low-dot { background: #b91c1c; box-shadow: 0 0 0 2px rgba(185, 28, 28, 0.18); }
+
       .toolbar {
         display: flex;
         gap: 12px;

--- a/templates/checkout_start.html
+++ b/templates/checkout_start.html
@@ -890,7 +890,9 @@
     resultsList.innerHTML = items.map(item => {
       const isKey = item.type === 'Key';
       const copiesInfo = isKey && item.checkout_quantity ? ` (${item.checkout_quantity} cop${item.checkout_quantity > 1 ? 'ies' : 'y'})` : '';
-      const statusBadge = item.status === 'checked_out' ? '<span class="tag warn">Checked Out</span>' : '<span class="tag ok">Assigned</span>';
+      const statusClass = 'status-' + (item.status || 'unknown').toLowerCase().replace(/_/g, '-');
+      const statusLabel = item.status === 'checked_out' ? 'Checked Out' : 'Assigned';
+      const statusBadge = `<span class="tag ${statusClass}">${statusLabel}</span>`;
 
       return `
         <div class="card" style="padding: 16px;">

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -120,7 +120,14 @@
       </tbody>
     </table>
   {% else %}
-    <div class="empty-state">No contacts found.</div>
+    <div class="empty-state">
+      <h3>No contacts yet</h3>
+      <p>Add tenants, contractors, agents, and staff. Contact email addresses are used for checkout / overdue notifications.</p>
+      <div class="toolbar">
+        <a class="btn primary" href="{{ url_for('contacts.create_contact') }}">Add your first contact</a>
+        <a class="btn ghost" href="{{ safe_url('contacts.import_contacts') }}">Import from CSV</a>
+      </div>
+    </div>
   {% endif %}
 </div>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -252,7 +252,7 @@
           <td><strong>{{ item.label }}</strong></td>
           <td><span class="muted">{{ item.type }}</span></td>
           <td>
-            <span class="tag {{ 'ok' if item.status == 'assigned' else 'warn' }}">
+            <span class="tag status-{{ (item.status or 'unknown')|lower|replace('_', '-') }}">
               {{ item.status|replace('_', ' ')|title }}
             </span>
           </td>

--- a/templates/import_map.html
+++ b/templates/import_map.html
@@ -73,12 +73,12 @@
       <div style="overflow-x: auto; margin-bottom: 20px;">
         <table class="preview-table" style="width: 100%; border-collapse: collapse;">
           <thead>
-            <tr style="background: #f5f5f5;">
+            <tr style="background: rgba(148, 163, 184, 0.08);">
               {% for header in import_data.headers[:10] %}
-                <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">{{ header }}</th>
+                <th style="padding: 10px; border: 1px solid var(--color-border); text-align: left;">{{ header }}</th>
               {% endfor %}
               {% if import_data.headers|length > 10 %}
-                <th style="padding: 10px; border: 1px solid #ddd;">...</th>
+                <th style="padding: 10px; border: 1px solid var(--color-border);">...</th>
               {% endif %}
             </tr>
           </thead>
@@ -86,10 +86,10 @@
             {% for row in import_data.rows[:5] %}
               <tr>
                 {% for header in import_data.headers[:10] %}
-                  <td style="padding: 10px; border: 1px solid #ddd;">{{ row.get(header, '') }}</td>
+                  <td style="padding: 10px; border: 1px solid var(--color-border);">{{ row.get(header, '') }}</td>
                 {% endfor %}
                 {% if import_data.headers|length > 10 %}
-                  <td style="padding: 10px; border: 1px solid #ddd;">...</td>
+                  <td style="padding: 10px; border: 1px solid var(--color-border);">...</td>
                 {% endif %}
               </tr>
             {% endfor %}

--- a/templates/import_preview.html
+++ b/templates/import_preview.html
@@ -15,10 +15,10 @@
     </div>
 
     <h3>Mapped Fields</h3>
-    <div class="field-mapping-summary" style="margin-bottom: 30px; padding: 15px; background: #f9f9f9; border-radius: 8px;">
+    <div class="field-mapping-summary" style="margin-bottom: 30px; padding: 15px; background: rgba(148, 163, 184, 0.06); border-radius: 8px;">
       <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
         {% for field_name, column in mapping.items() %}
-          <div style="padding: 8px; background: white; border-radius: 4px; border: 1px solid #e0e0e0;">
+          <div style="padding: 8px; background: var(--color-card); border-radius: 4px; border: 1px solid var(--color-border);">
             <strong>{{ fields[field_name].name }}:</strong>
             <span class="muted">{{ column }}</span>
           </div>
@@ -30,9 +30,9 @@
     <div style="overflow-x: auto; margin-bottom: 20px;">
       <table class="preview-table" style="width: 100%; border-collapse: collapse;">
         <thead>
-          <tr style="background: #f5f5f5;">
+          <tr style="background: rgba(148, 163, 184, 0.08);">
             {% for field_name in mapping.keys() %}
-              <th style="padding: 10px; border: 1px solid #ddd; text-align: left;">
+              <th style="padding: 10px; border: 1px solid var(--color-border); text-align: left;">
                 {{ fields[field_name].name }}
                 {% if fields[field_name].required %}<span style="color: var(--color-danger);">*</span>{% endif %}
               </th>
@@ -43,7 +43,7 @@
           {% for item in preview_data %}
             <tr>
               {% for field_name in mapping.keys() %}
-                <td style="padding: 10px; border: 1px solid #ddd;">
+                <td style="padding: 10px; border: 1px solid var(--color-border);">
                   {{ item.get(field_name, '') if item.get(field_name, '') else '-' }}
                 </td>
               {% endfor %}

--- a/templates/item_details.html
+++ b/templates/item_details.html
@@ -293,7 +293,7 @@
 
 <div class="page-header">
   <h1>{{ item.label }}</h1>
-  <span class="tag {{ 'ok' if status_lower in ['available', 'assigned'] else 'warn' }}">
+  <span class="tag status-{{ status_lower.replace('_', '-') }}">
     {{ (item.status or 'Unknown').replace('_',' ')|title }}
   </span>
 </div>
@@ -566,8 +566,8 @@
             <td style="padding: 8px; border-bottom: 1px solid var(--color-border);"><code>{{ child.custom_id or child.id }}</code></td>
             <td style="padding: 8px; border-bottom: 1px solid var(--color-border);">{{ child.label }}</td>
             <td style="padding: 8px; border-bottom: 1px solid var(--color-border);">
-              <span class="tag {% if child.status == 'available' %}ok{% elif child.status == 'checked_out' %}warn{% elif child.status == 'assigned' %}info{% endif %}">
-                {{ child.status.replace('_', ' ').title() }}
+              <span class="tag status-{{ (child.status or 'unknown')|lower|replace('_', '-') }}">
+                {{ (child.status or 'unknown').replace('_', ' ').title() }}
               </span>
             </td>
             <td style="padding: 8px; border-bottom: 1px solid var(--color-border);">{{ child.location or '-' }}</td>

--- a/templates/keys.html
+++ b/templates/keys.html
@@ -44,9 +44,12 @@
     font-size: 12px;
     font-weight: 600;
   }
-  .copy-badge.full { background: rgba(74, 222, 128, 0.18); color: #4ade80; }
-  .copy-badge.low { background: rgba(248, 113, 113, 0.18); color: var(--color-danger); }
+  .copy-badge.full   { background: rgba(74, 222, 128, 0.18); color: #4ade80; }
+  .copy-badge.low    { background: rgba(248, 113, 113, 0.18); color: var(--color-danger); }
   .copy-badge.medium { background: rgba(251, 191, 36, 0.18); color: #fbbf24; }
+  body.light .copy-badge.full   { background: rgba(21, 128, 61, 0.15); color: #15803d; }
+  body.light .copy-badge.low    { background: rgba(185, 28, 28, 0.15); color: #991b1b; }
+  body.light .copy-badge.medium { background: rgba(180, 83, 9, 0.15); color: #92400e; }
 
   /* Autocomplete styles */
   .autocomplete-wrapper {
@@ -230,17 +233,22 @@
         </tr>
       </thead>
       <tbody>
+        {% set low_threshold = tenant_settings.low_keys_threshold if tenant_settings else 4 %}
         {% for key in keys %}
           {% set status_lower = (key.status or '')|lower %}
           {% set total = key.total_copies or 0 %}
           {% set checked_out = key.copies_checked_out or 0 %}
           {% set available = total - checked_out %}
+          {% set is_low = total < low_threshold %}
           <tr data-item-id="{{ key.id }}" data-item-label="{{ key.label }}">
             <td class="select-col">
               <input type="checkbox" class="item-checkbox" value="{{ key.id }}" onchange="updateBulkToolbar()" style="margin: 0;">
             </td>
             <td>
-              <div><strong><a href="{{ url_for('inventory.item_details', item_id=key.id) }}" style="color: inherit; text-decoration: none;">{{ key.label }}</a></strong></div>
+              <div>
+                <strong><a href="{{ url_for('inventory.item_details', item_id=key.id) }}" style="color: inherit; text-decoration: none;">{{ key.label }}</a></strong>
+                {% if is_low %}<span class="low-dot" title="Total copies below threshold ({{ total }} of {{ low_threshold }} minimum)" aria-label="Total copies below threshold"></span>{% endif %}
+              </div>
               <div class="muted">{{ key.custom_id or '-' }}</div>
             </td>
             <td>
@@ -261,7 +269,7 @@
             <td>{{ key.location or '-' }}<br><span class="muted text-small">Hook #{{ key.key_hook_number or '-' }}</span></td>
             <td>
               <div class="copy-info">
-                <span class="copy-badge {{ 'full' if total >= 6 else ('low' if total < 4 else 'medium') }}">
+                <span class="copy-badge {{ 'low' if is_low else ('medium' if total < low_threshold + 2 else 'full') }}">
                   {{ total }} total
                 </span>
                 <span class="muted text-small">{{ available }} avail</span>
@@ -269,7 +277,7 @@
             </td>
             <td>
               {% set st_lower = (key.status or 'Unknown')|lower %}
-              <span class="tag {{ 'ok' if st_lower in ['available', 'assigned'] else 'warn' }}">{{ (key.status or 'Unknown').replace('_',' ')|title }}</span>
+              <span class="tag status-{{ st_lower.replace('_', '-') }}">{{ (key.status or 'Unknown').replace('_',' ')|title }}</span>
             </td>
             <td>
               {{ key.assigned_to or '-' }}

--- a/templates/keys.html
+++ b/templates/keys.html
@@ -359,7 +359,14 @@
       </tbody>
     </table>
   {% else %}
-    <div class="empty-state">No keys found.</div>
+    <div class="empty-state">
+      <h3>No keys yet</h3>
+      <p>Track keys, copies, and who has them.</p>
+      <div class="toolbar">
+        <a class="btn primary" href="{{ url_for('inventory.add_key') }}">Add your first key</a>
+        <a class="btn ghost" href="{{ url_for('inventory.import_keys') }}">Import from CSV</a>
+      </div>
+    </div>
   {% endif %}
 </div>
 
@@ -1177,6 +1184,18 @@
     }
   }
 
+  // Shared post-action handler. Shows a toast with the result, then reloads
+  // briefly later so the user has time to read it.
+  function handleBulkResult(data, operation) {
+    if (data && data.success) {
+      toast(data.message || `${operation} complete`, { type: 'success' });
+      setTimeout(() => window.location.reload(), 700);
+    } else {
+      const msg = (data && data.error) || `${operation} failed`;
+      toast('Error: ' + msg, { type: 'error', duration: 0 });
+    }
+  }
+
   async function bulkDelete(itemIds) {
     try {
       const response = await fetch('/inventory/bulk/delete', {
@@ -1190,16 +1209,9 @@
           item_type: 'key'
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk delete');
     } catch (error) {
-      alert('Error performing bulk delete: ' + error);
+      toast('Error performing bulk delete: ' + error, { type: 'error', duration: 0 });
     }
   }
 
@@ -1216,16 +1228,9 @@
           status: newStatus
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk status update');
     } catch (error) {
-      alert('Error performing bulk status update: ' + error);
+      toast('Error performing bulk status update: ' + error, { type: 'error', duration: 0 });
     }
   }
 
@@ -1242,16 +1247,9 @@
           assigned_to: assignTo
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk assign');
     } catch (error) {
-      alert('Error performing bulk assign: ' + error);
+      toast('Error performing bulk assign: ' + error, { type: 'error', duration: 0 });
     }
   }
 </script>

--- a/templates/lockboxes.html
+++ b/templates/lockboxes.html
@@ -258,7 +258,14 @@
       </tbody>
     </table>
   {% else %}
-    <p class="muted">No lockboxes found. <a href="{{ url_for('inventory.add_lockbox') }}">Add your first lockbox</a>.</p>
+    <div class="empty-state">
+      <h3>No lockboxes yet</h3>
+      <p>Track lockbox codes, locations, and who's using them.</p>
+      <div class="toolbar">
+        <a class="btn primary" href="{{ url_for('inventory.add_lockbox') }}">Add your first lockbox</a>
+        <a class="btn ghost" href="{{ url_for('inventory.import_lockboxes') }}">Import from CSV</a>
+      </div>
+    </div>
   {% endif %}
 </div>
 
@@ -410,6 +417,16 @@
     }
   }
 
+  function handleBulkResult(data, operation) {
+    if (data && data.success) {
+      toast(data.message || `${operation} complete`, { type: 'success' });
+      setTimeout(() => window.location.reload(), 700);
+    } else {
+      const msg = (data && data.error) || `${operation} failed`;
+      toast('Error: ' + msg, { type: 'error', duration: 0 });
+    }
+  }
+
   async function bulkDelete(itemIds) {
     try {
       const response = await fetch('/inventory/bulk/delete', {
@@ -423,16 +440,9 @@
           item_type: 'lockbox'
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk delete');
     } catch (error) {
-      alert('Error performing bulk delete: ' + error);
+      toast('Error performing bulk delete: ' + error, { type: 'error', duration: 0 });
     }
   }
 
@@ -449,16 +459,9 @@
           status: newStatus
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk status update');
     } catch (error) {
-      alert('Error performing bulk status update: ' + error);
+      toast('Error performing bulk status update: ' + error, { type: 'error', duration: 0 });
     }
   }
 
@@ -475,16 +478,9 @@
           assigned_to: assignTo
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk assign');
     } catch (error) {
-      alert('Error performing bulk assign: ' + error);
+      toast('Error performing bulk assign: ' + error, { type: 'error', duration: 0 });
     }
   }
 </script>

--- a/templates/lockboxes.html
+++ b/templates/lockboxes.html
@@ -214,7 +214,7 @@
             </td>
             <td>
               {% set st_lower = (lb.status or 'Unknown')|lower %}
-              <span class="tag {{ 'ok' if st_lower in ['available', 'assigned'] else 'warn' }}">
+              <span class="tag status-{{ st_lower.replace('_', '-') }}">
                 {{ (lb.status or 'Unknown').replace('_',' ')|title }}
               </span>
             </td>

--- a/templates/properties.html
+++ b/templates/properties.html
@@ -112,7 +112,14 @@
     </div>
   {% else %}
     <div class="card">
-      <div class="empty-state">No properties found.</div>
+      <div class="empty-state">
+        <h3>No properties yet</h3>
+        <p>Add the addresses you manage. Items can then be assigned to specific properties for clearer reporting.</p>
+        <div class="toolbar">
+          <a class="btn primary" href="{{ url_for('properties.create_property') }}">Add your first property</a>
+          <a class="btn ghost" href="{{ safe_url('properties.import_properties') }}">Import from CSV</a>
+        </div>
+      </div>
     </div>
   {% endfor %}
 </div>

--- a/templates/receipt_lookup.html
+++ b/templates/receipt_lookup.html
@@ -12,29 +12,38 @@
 </div>
 
 <div class="card" style="margin-bottom: 24px;">
-  <h3>Search Receipts</h3>
-  <p class="muted" style="margin-bottom: 16px;">
-    Search by receipt number, barcode (RCP######), person's name, item label, item ID, or address.
-    Barcode scanners are automatically detected.
-  </p>
-
   <form method="GET" action="{{ url_for('inventory.receipt_lookup') }}" id="search-form">
     <div class="form-field">
-      <label for="search-input">Receipt Search</label>
-      <input
-        type="text"
-        id="search-input"
-        name="q"
-        value="{{ query }}"
-        placeholder="Scan barcode or type receipt number, name..."
-        autofocus
-        autocomplete="off"
-      >
-      <p class="muted text-small" style="margin-top: 4px;">
+      <label for="search-input">Search receipts</label>
+      <div class="searchbar" style="padding: 8px 10px;">
+        <input
+          type="text"
+          id="search-input"
+          name="q"
+          value="{{ query }}"
+          placeholder="Receipt #, barcode, name, item, or address…"
+          autofocus
+          autocomplete="off"
+          style="flex: 1; font-size: 15px; padding: 6px 4px;"
+        >
+        <button type="submit" class="btn primary small">Search</button>
+        {% if query %}
+          <a class="btn ghost small" href="{{ url_for('inventory.receipt_lookup') }}">Clear</a>
+        {% endif %}
+      </div>
+    </div>
+    <details style="margin-top: 8px;">
+      <summary class="muted text-small" style="cursor: pointer; user-select: none;">
+        Search tips &amp; barcode scanner status
+      </summary>
+      <p class="muted text-small" style="margin: 8px 0 0;">
+        Search by receipt number, barcode (<code>RCP######</code>), person's name,
+        item label, item ID, or address. Barcode scanners are automatically detected.
+      </p>
+      <p class="muted text-small" style="margin: 4px 0 0;">
         <span id="scanner-status">Ready for barcode scanner input</span>
       </p>
-    </div>
-    <button type="submit" class="btn primary">Search</button>
+    </details>
   </form>
 </div>
 

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -161,7 +161,7 @@
                 <td><strong>{{ item.label }}</strong><br><span class="muted text-small">{{ item.custom_id or "-" }}</span></td>
                 <td><span class="muted">{{ item.type }}</span></td>
                 <td>
-                  <span class="tag {{ 'ok' if item.status == 'assigned' else 'warn' }}">
+                  <span class="tag status-{{ (item.status or 'unknown')|lower|replace('_', '-') }}">
                     {{ item.status|replace('_', ' ')|title }}
                   </span>
                 </td>
@@ -309,7 +309,7 @@
                 <td><strong>{{ item.label }}</strong><br><span class="muted text-small">{{ item.custom_id or "-" }}</span></td>
                 <td><span class="muted">{{ item.type }}</span></td>
                 <td>
-                  <span class="tag {{ 'ok' if item.status == 'assigned' else 'warn' }}">
+                  <span class="tag status-{{ (item.status or 'unknown')|lower|replace('_', '-') }}">
                     {{ item.status|replace('_', ' ')|title }}
                   </span>
                 </td>
@@ -394,7 +394,7 @@
                   <td class="muted">{{ key.copies_checked_out or 0 }}</td>
                   <td class="muted">{{ available }}</td>
                   <td>
-                    <span class="tag {{ 'ok' if key.status == 'available' else '' }}">
+                    <span class="tag status-{{ (key.status or 'unknown')|lower|replace('_', '-') }}">
                       {{ key.status|replace('_', ' ')|title }}
                     </span>
                   </td>

--- a/templates/signs.html
+++ b/templates/signs.html
@@ -356,7 +356,14 @@
       </tbody>
     </table>
   {% else %}
-    <div class="empty-state">No signs found.</div>
+    <div class="empty-state">
+      <h3>No signs yet</h3>
+      <p>Track for-sale signs, riders, and storage locations.</p>
+      <div class="toolbar">
+        <a class="btn primary" href="{{ url_for('inventory.add_sign') }}">Add your first sign</a>
+        <a class="btn ghost" href="{{ url_for('inventory.import_signs') }}">Import from CSV</a>
+      </div>
+    </div>
   {% endif %}
 </div>
 
@@ -832,6 +839,16 @@
     }
   }
 
+  function handleBulkResult(data, operation) {
+    if (data && data.success) {
+      toast(data.message || `${operation} complete`, { type: 'success' });
+      setTimeout(() => window.location.reload(), 700);
+    } else {
+      const msg = (data && data.error) || `${operation} failed`;
+      toast('Error: ' + msg, { type: 'error', duration: 0 });
+    }
+  }
+
   async function bulkDelete(itemIds) {
     try {
       const response = await fetch('/inventory/bulk/delete', {
@@ -845,16 +862,9 @@
           item_type: 'sign'
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk delete');
     } catch (error) {
-      alert('Error performing bulk delete: ' + error);
+      toast('Error performing bulk delete: ' + error, { type: 'error', duration: 0 });
     }
   }
 
@@ -871,16 +881,9 @@
           status: newStatus
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk status update');
     } catch (error) {
-      alert('Error performing bulk status update: ' + error);
+      toast('Error performing bulk status update: ' + error, { type: 'error', duration: 0 });
     }
   }
 
@@ -897,16 +900,9 @@
           assigned_to: assignTo
         })
       });
-
-      const data = await response.json();
-      if (data.success) {
-        alert(data.message);
-        window.location.reload();
-      } else {
-        alert('Error: ' + data.error);
-      }
+      handleBulkResult(await response.json(), 'Bulk assign');
     } catch (error) {
-      alert('Error performing bulk assign: ' + error);
+      toast('Error performing bulk assign: ' + error, { type: 'error', duration: 0 });
     }
   }
 

--- a/templates/signs.html
+++ b/templates/signs.html
@@ -271,7 +271,7 @@
             <td>{{ sign.location or '-' }}</td>
             <td>
               {% set st_lower = (sign.status or 'Unknown')|lower %}
-              <span class="tag {{ 'ok' if st_lower in ['available', 'assigned'] else 'warn' }}">{{ (sign.status or 'Unknown').replace('_',' ')|title }}</span>
+              <span class="tag status-{{ st_lower.replace('_', '-') }}">{{ (sign.status or 'Unknown').replace('_',' ')|title }}</span>
             </td>
             <td>
               {{ sign.assigned_to or '-' }}

--- a/templates/smartlocks.html
+++ b/templates/smartlocks.html
@@ -49,7 +49,22 @@
       </tbody>
     </table>
   {% else %}
-    <div class="empty-state">No smart lock codes recorded.</div>
+    <div class="empty-state">
+      {% if q %}
+        <h3>No matches</h3>
+        <p>No smart locks match "{{ q }}".</p>
+        <div class="toolbar">
+          <a class="btn ghost" href="{{ url_for('smartlocks.list_smartlocks') }}">Clear search</a>
+        </div>
+      {% else %}
+        <h3>No smart locks yet</h3>
+        <p>Track door locks and pairing codes — never lose a Schlage sticker again.</p>
+        <div class="toolbar">
+          <a class="btn primary" href="{{ url_for('smartlocks.create_smartlock') }}">Add your first smart lock</a>
+          <a class="btn ghost" href="{{ url_for('smartlocks.import_smartlocks') }}">Import from CSV</a>
+        </div>
+      {% endif %}
+    </div>
   {% endif %}
 </div>
 {% endblock %}

--- a/templates/unit_detail.html
+++ b/templates/unit_detail.html
@@ -86,8 +86,8 @@
           <td><code>{{ key.custom_id or key.id }}</code></td>
           <td>{{ key.label }}</td>
           <td>
-            <span class="tag {% if key.status == 'available' %}ok{% elif key.status == 'checked_out' %}warn{% elif key.status == 'assigned' %}info{% endif %}">
-              {{ key.status.replace('_', ' ').title() }}
+            <span class="tag status-{{ (key.status or 'unknown')|lower|replace('_', '-') }}">
+              {{ (key.status or 'unknown').replace('_', ' ').title() }}
             </span>
           </td>
           <td>{{ key.location or '-' }}</td>


### PR DESCRIPTION
## What

Concrete fixes from a UX survey across the app. Skips the bigger structural items (replacing every \`alert()\`, inline form validation everywhere) — those are separate efforts.

### Toast notification system (\`templates/base.html\`)
- New global \`window.toast(message, {type, duration})\` helper. Themed, non-blocking, drops in the bottom-right. Click to dismiss, auto-dismiss after 4.5s (sticky with \`duration: 0\`).
- Used as the \`alert()\` replacement starting with the bulk-action handlers below.

### Flash message polish
- Added explicit \`.flash.error\` and \`.flash.warning\` styles — they used to collapse to identical visuals (red).
- Light-mode flashes now have proper contrast.
- Auto-dismiss after 6s; errors stick around 12s. Click to dismiss earlier.

### Error pages (404 / 403 / 500)
- All three rewritten to extend \`base.html\` and use theme variables. Previously 404/403 used Tailwind grays that rendered illegibly in dark mode, and 500 was a standalone hardcoded-dark template. Now consistent.
- Each has Go Home + Go Back / Try Again actions.

### Mobile toolbar stacking
- \`@media (max-width: 720px)\` stacks toolbar children vertically full-width. Previously toolbars overflowed on phones.

### Dark-mode CSS bugs
- \`import_map.html\` and \`import_preview.html\` had hardcoded \`#f5f5f5\`, \`#ddd\`, \`white\`, \`#f9f9f9\`, \`#e0e0e0\`. Replaced with theme variables.

### Empty states with onboarding CTAs
- keys / lockboxes / signs / smartlocks / contacts / properties: each empty-state card now has an h3 + description + primary "Add your first X" + secondary "Import from CSV" CTA. Previously most just said "No X found."

### Receipts page
- Big intro paragraph collapsed into a \`<details>\` "Search tips" disclosure — the search input is now the first thing visible.
- Search + Clear buttons inline with the input.

### Bulk-action result toasts
- keys / lockboxes / signs each had 4-6 \`alert()\` calls in their bulk-delete / status / assign handlers (18 total). Refactored to share \`handleBulkResult()\` that shows a toast on success/error and reloads after 700ms so the toast is readable.

## Out of scope (other findings worth doing later)
- 30+ remaining \`alert()\` / \`confirm()\` calls in keys/lockboxes/signs/system_updates — replace with toast/modal in subsequent passes.
- Inline form validation (only \`checkout_start.html\` has it today).
- Reorganizing keys/lockboxes row actions into an overflow ⋯ menu (6 same-style buttons per row).

## Test plan
- [ ] Trigger a bulk delete → see a green toast with the count, page reloads after a moment.
- [ ] Visit any list page with zero items → see h3 + description + two CTA buttons in the empty state.
- [ ] Visit /receipts → search input is the first thing on the page; click "Search tips" to expand.
- [ ] Force a 404 (random URL) → themed page with red 404, both home and back buttons.
- [ ] Resize browser to phone width → toolbars stack, search bars full-width.
- [ ] Trigger any flash message → it auto-dismisses after a few seconds; click to dismiss earlier.
- [ ] Open browser console, run \`toast('hi', {type: 'success'})\` → green toast appears bottom-right.