### PR TITLE
CSRF: tie token lifetime to session

### DIFF
--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -201,6 +201,12 @@ def create_app():
             return None
 
     # 10a) CSRF Protection
+    # Tie token lifetime to the session, not Flask-WTF's default 1-hour cap.
+    # Without this, a page that's been open for >1h will fail any POST with
+    # "CSRF token expired" even though the user is still logged in. The
+    # tokens are still per-session and signed, so this doesn't weaken the
+    # protection — it just removes the redundant clock.
+    app.config.setdefault("WTF_CSRF_TIME_LIMIT", None)
     csrf.init_app(app)
 
     # 10b) Rate Limiting

--- a/templates/app_admin/system_updates.html
+++ b/templates/app_admin/system_updates.html
@@ -294,7 +294,9 @@
       // Check if response is OK before parsing JSON
       if (!response.ok) {
         const text = await response.text();
-        throw new Error(`Server error (${response.status}): ${text.substring(0, 100)}`);
+        // Strip Flask's HTML error-page wrapper to show just the message.
+        const cleaned = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().substring(0, 300);
+        throw new Error(`Server error (${response.status}): ${cleaned}`);
       }
 
       const result = await response.json();
@@ -398,7 +400,9 @@
       // Check if response is OK before parsing JSON
       if (!response.ok) {
         const text = await response.text();
-        throw new Error(`Server error (${response.status}): ${text.substring(0, 100)}`);
+        // Strip Flask's HTML error-page wrapper to show just the message.
+        const cleaned = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().substring(0, 300);
+        throw new Error(`Server error (${response.status}): ${cleaned}`);
       }
 
       const data = await response.json();


### PR DESCRIPTION
## What

Two related fixes for the \`Bad Request: The CSRF token …\` failure that just hit the in-app updater UI.

1. **\`WTF_CSRF_TIME_LIMIT = None\`** in the app factory. Flask-WTF's default 1-hour cap is independent of session lifetime, so any page open for >1h fails its next POST with an expired-token error even when the session is still active. Tying the token lifetime to the session removes a redundant clock — tokens are still per-session and signed, so protection is unchanged.

2. **system_updates.html**: stop truncating Flask's HTML error response at 100 chars. The user just saw \`Server error (400): Bad Request The CSRF token\` cut off mid-sentence. Now strips HTML, shows up to 300 chars of plain text, so future debug sessions actually have the message.

## Existing deployments

Just merge + restart. Already-open browser tabs still need a refresh to pick up new tokens (no way to retroactively extend tokens already issued), but new sessions won't hit the 1-hour limit anymore.

## Test plan
- [ ] Merge + restart python-app
- [ ] Hard-refresh System Updates page → click Update Now → no CSRF error
- [ ] Leave the page open for >1h, click Update Now again → still works