### PR TITLE
Idle session timeout + client-side logout warning

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -44,10 +44,14 @@ TIMEOUT=120
 LOG_LEVEL=info
 
 # Sessions
+# PERMANENT_SESSION_LIFETIME is the *idle* timeout in seconds — sessions are
+# refreshed on every request, so this only fires after that many seconds of
+# zero activity. 1800 = 30 min, a good security/usability balance for an
+# admin tool. The client-side warning toast appears 5 minutes before this.
 SESSION_COOKIE_SECURE=true
 SESSION_COOKIE_HTTPONLY=true
 SESSION_COOKIE_SAMESITE=Lax
-PERMANENT_SESSION_LIFETIME=3600
+PERMANENT_SESSION_LIFETIME=1800
 
 # Uploads (16 MiB)
 MAX_CONTENT_LENGTH=16777216

--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -50,6 +50,20 @@ def create_app():
     # 1) Load config
     app.config.from_object(get_config())
 
+    # Session idle timeout. Sessions are marked permanent on login (see
+    # auth.views_multitenant), and Flask's SESSION_REFRESH_EACH_REQUEST is
+    # True by default — together that gives us sliding-window idle timeout:
+    # the cookie's expiry is reset on every request, so active users never
+    # get bumped while idle ones do.
+    #
+    # Default 30 minutes. Override via PERMANENT_SESSION_LIFETIME env var
+    # (in seconds) to make it longer/shorter per deployment.
+    try:
+        app.config["PERMANENT_SESSION_LIFETIME"] = int(os.getenv("PERMANENT_SESSION_LIFETIME", "1800"))
+    except ValueError:
+        app.config["PERMANENT_SESSION_LIFETIME"] = 1800
+    app.config.setdefault("SESSION_REFRESH_EACH_REQUEST", True)
+
     # 2) Set up master database path (use Docker volume mount)
     master_base_dir = Path("master_db")
     master_base_dir.mkdir(parents=True, exist_ok=True)

--- a/auth/views_multitenant.py
+++ b/auth/views_multitenant.py
@@ -171,6 +171,12 @@ def login_post():
         user.last_login_at = datetime.now(UTC).replace(tzinfo=None)
 
         login_user(user, remember=remember)
+        # Mark the session permanent so PERMANENT_SESSION_LIFETIME applies and
+        # SESSION_REFRESH_EACH_REQUEST gives us a sliding idle timeout. Without
+        # this, sessions live until the browser closes regardless of how long
+        # they've been idle.
+        from flask import session
+        session.permanent = True
         master_db.session.commit()
 
         # Redirect based on role

--- a/templates/base.html
+++ b/templates/base.html
@@ -1383,6 +1383,65 @@
         }
       })();
 
+      // ----------------------------------------------------------------
+      //  Idle session timeout (client-side warning + redirect)
+      // ----------------------------------------------------------------
+      // Server-side, sessions are sliding-window: every request resets the
+      // cookie expiry, and PERMANENT_SESSION_LIFETIME (default 30 min) is
+      // the idle ceiling. This script mirrors that on the client so the
+      // user gets a heads-up toast a few minutes before timeout, then a
+      // graceful redirect to logout when it actually fires — instead of
+      // their next click silently 401-ing.
+      {% if current_user.is_authenticated %}
+      (function () {
+        const TIMEOUT_SEC = {{ config.get('PERMANENT_SESSION_LIFETIME', 1800) }};
+        if (TIMEOUT_SEC <= 0) return;
+
+        const TIMEOUT_MS = TIMEOUT_SEC * 1000;
+        // Warn 5 min before timeout, or 20% before, whichever is shorter.
+        const WARN_BEFORE_MS = Math.min(5 * 60 * 1000, TIMEOUT_MS * 0.2);
+        const WARN_AT_MS = Math.max(TIMEOUT_MS - WARN_BEFORE_MS, TIMEOUT_MS / 2);
+        const LOGOUT_URL = '{{ url_for("auth.logout") }}';
+
+        let lastActivity = Date.now();
+        let warnedToastEl = null;
+
+        function recordActivity() {
+          lastActivity = Date.now();
+          if (warnedToastEl) {
+            warnedToastEl.click();  // dismisses via the toast click handler
+            warnedToastEl = null;
+          }
+        }
+
+        // Anything that suggests the user is still around resets the timer.
+        // Use passive listeners to keep scroll smooth on touch devices.
+        ['mousedown', 'keydown', 'touchstart', 'scroll'].forEach(function (evt) {
+          document.addEventListener(evt, recordActivity, { passive: true });
+        });
+
+        function tick() {
+          const idleMs = Date.now() - lastActivity;
+          if (idleMs >= TIMEOUT_MS) {
+            // Hard logout. The server-side session may still be just-barely
+            // alive, but the cookie is about to be rejected; bouncing through
+            // /auth/logout cleanly clears state.
+            window.location.href = LOGOUT_URL;
+            return;
+          }
+          if (idleMs >= WARN_AT_MS && !warnedToastEl && typeof window.toast === 'function') {
+            const minsLeft = Math.max(1, Math.ceil((TIMEOUT_MS - idleMs) / 60000));
+            warnedToastEl = window.toast(
+              `Logging out in ${minsLeft} min due to inactivity. Click anywhere to stay.`,
+              { type: 'warning', duration: 0 }
+            );
+          }
+        }
+        // Check every 30 seconds — minimal overhead, fine resolution.
+        setInterval(tick, 30000);
+      })();
+      {% endif %}
+
       // ---- Global search autocomplete ----
       (function () {
         const form = document.getElementById('global-search');


### PR DESCRIPTION
## What

Sliding-window idle timeout: active users stay logged in indefinitely, idle users auto-log-out after N minutes. Default 30 min (configurable via \`PERMANENT_SESSION_LIFETIME\` env var).

A few minutes before timeout, a sticky warning toast appears: *"Logging out in N min due to inactivity. Click anywhere to stay."* Any user activity (mousedown / keydown / touchstart / scroll) dismisses it and resets the timer.

## Why

You asked for it as a security hardening + as a side effect it eliminates the CSRF-token-vs-session-lifetime race that just bit us. With a 30-min idle ceiling, an active session can never outlive its CSRF token, and an idle session is gone before either becomes a problem.

## Server side
- \`auth.login\`: \`session.permanent = True\` after \`login_user()\`. Without it, \`PERMANENT_SESSION_LIFETIME\` doesn't apply and the cookie lives until browser close.
- App factory: explicit \`SESSION_REFRESH_EACH_REQUEST=True\` (also Flask's default — making it explicit so it can't accidentally flip).
- \`.env.production.template\`: default lowered from 3600 (1 hour) to 1800 (30 min) with a comment explaining the sliding behavior.

## Client side (templates/base.html)
- New idle-tracker block, only renders for authenticated users.
- TIMEOUT_SEC is templated from \`app.config\` at render time so client and server can never drift.
- Tick every 30 seconds; warning fires 5 min before timeout (or 20% earlier, whichever is shorter, so very short configured timeouts still get a heads-up).

## Existing deployments
- Merge + deploy.
- If you want a different timeout than 30 min, set \`PERMANENT_SESSION_LIFETIME=N\` (in seconds) in \`/opt/kbm/.env\` and restart.

## Test plan
- [ ] Log in, leave page idle for 25 min → warning toast appears
- [ ] Click anywhere → toast dismisses, timer resets
- [ ] Leave idle for 30+ min → redirected to /auth/login
- [ ] Set PERMANENT_SESSION_LIFETIME=120 (2 min) for quick local testing → warning at ~95s, logout at 120s