### PR TITLE
Fix UX-polish regressions: keys 500, signs column shift

### DIFF
--- a/templates/keys.html
+++ b/templates/keys.html
@@ -233,7 +233,10 @@
         </tr>
       </thead>
       <tbody>
-        {% set low_threshold = tenant_settings.low_keys_threshold if tenant_settings else 4 %}
+        {# Defensive: fall back to 4 if the tenant settings row exists but
+           low_keys_threshold is somehow None (pre-backfill DB state). #}
+        {% set _raw_threshold = tenant_settings.low_keys_threshold if tenant_settings else None %}
+        {% set low_threshold = _raw_threshold if (_raw_threshold is not none) else 4 %}
         {% for key in keys %}
           {% set status_lower = (key.status or '')|lower %}
           {% set total = key.total_copies or 0 %}

--- a/templates/signs.html
+++ b/templates/signs.html
@@ -244,7 +244,10 @@
           {% set is_piece = sign.sign_subtype == 'Piece' %}
           {% set is_assembled = sign.sign_subtype == 'Assembled Unit' %}
           {% set has_parent = sign.parent_sign_id is not none %}
-          <tr>
+          <tr data-item-id="{{ sign.id }}" data-item-label="{{ sign.label }}">
+            <td class="select-col">
+              <input type="checkbox" class="item-checkbox" value="{{ sign.id }}" onchange="updateBulkToolbar()" style="margin: 0;">
+            </td>
             <td>
               <div><strong><a href="{{ url_for('inventory.item_details', item_id=sign.id) }}" style="color: inherit; text-decoration: none;">{{ sign.label }}</a></strong></div>
               <div class="muted">{{ sign.custom_id or '-' }}</div>


### PR DESCRIPTION
## What

Two regressions from PR #32 reported on the live VPS:

1. **Keys page 500**: \`total < low_threshold + 2\` raised \`TypeError\` when \`tenant_settings.low_keys_threshold\` was \`None\`. Now defensively falls back to 4 if the value is None, separately from the \`tenant_settings is None\` case, so neither path can crash.

2. **Signs page columns misaligned**: header has 11 columns but each \`<tr>\` was missing the leading select-col cell. Restored it so columns line up and the bulk-action toolbar at the top of signs.html actually has rows it can target.

## What about lockboxes?

User also reported \"assigned\" lockboxes rendering grey instead of blue. The \`.tag.status-assigned\` rule renders blue and the lockboxes template applies the right class. Most likely cause: browser cache. After deploy, hard-refresh (\`Ctrl+Shift+R\` / \`Cmd+Shift+R\`) the lockboxes page. If still grey, file with the rendered \`<span>\` HTML so I can see the actual classes.

## Test plan
- [ ] Keys page renders without 500
- [ ] Signs page columns align under the header (Label / Type / Piece Type / Condition / Address / Location / Status / Assigned To / Last Action / Actions all match)
- [ ] Bulk-select checkbox column visible at the start of each signs row
- [ ] Hard-refresh lockboxes page → confirm \"assigned\" shows blue. If not, paste rendered HTML.