### PR TITLE
Remove property field from Add Lockbox form

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -373,27 +373,12 @@ def bulk_assign():
 @login_required
 @tenant_required
 def add_lockbox():
-    properties = tenant_query(Property).order_by(Property.name.asc()).all()
+    """Create a new lockbox.
 
-    def _property_display(prop: Property) -> str:
-        address_bits = [prop.address_line1, prop.city, prop.state]
-        address = ", ".join([bit for bit in address_bits if bit])
-        return f"{prop.name} - {address}" if address else prop.name
-
-    property_choices: list[dict[str, str]] = []
-    property_lookup: dict[str, dict[str, str | None]] = {}
-    for prop in properties:
-        entry = {
-            "id": str(prop.id),
-            "display": _property_display(prop),
-            "address_line1": prop.address_line1,
-            "city": prop.city,
-            "state": prop.state,
-            "postal_code": prop.postal_code,
-        }
-        property_choices.append(entry)
-        property_lookup[entry["id"]] = entry
-
+    The Add form intentionally does NOT collect a property — assignment to
+    a property is a separate step you do from the lockbox's detail page
+    (Edit), so the create form stays focused on the physical lockbox itself.
+    """
     if request.method == "POST":
         label = (request.form.get("label") or "").strip()
         location = (request.form.get("location") or "").strip()
@@ -414,25 +399,6 @@ def add_lockbox():
             flash("Label is required.", "error")
             return redirect(url_for("inventory.add_lockbox"))
 
-        property_id_str = (request.form.get("property_id") or "").strip()
-        property_obj = None
-        if property_id_str:
-            try:
-                property_obj = get_tenant_session().get(Property, int(property_id_str))
-            except ValueError:
-                property_obj = None
-            if property_obj is None:
-                flash("Selected property could not be found.", "error")
-                return redirect(url_for("inventory.add_lockbox"))
-            if not address:
-                address_parts = [
-                    property_obj.address_line1,
-                    property_obj.city,
-                    property_obj.state,
-                    property_obj.postal_code,
-                ]
-                address = ", ".join([part for part in address_parts if part])
-
         # Generate custom ID
         custom_id = Item.generate_custom_id("Lockbox")
 
@@ -449,7 +415,6 @@ def add_lockbox():
             last_action="created",
             last_action_at=utc_now(),
             last_action_by_id=getattr(current_user, "id", None),
-            property_id=property_obj.id if property_obj else None,
         )
         tenant_add(item)
         tenant_flush()
@@ -464,19 +429,14 @@ def add_lockbox():
                 "address": item.address,
                 "code": code,
                 "supra_id": supra_id,
-                "property_id": property_obj.id if property_obj else None,
             },
             commit=False,
         )
         tenant_commit()
-        flash("Lockbox added.", "success")
+        flash("Lockbox added. Open the lockbox to assign it to a property.", "success")
         return redirect(url_for("inventory.list_lockboxes"))
 
-    return render_template(
-        "lockbox_add.html",
-        properties=property_choices,
-        property_lookup=property_lookup,
-    )
+    return render_template("lockbox_add.html")
 
 # --- Quick check out (requires entering current code) ---
 @inventory_bp.route("/lockboxes/<int:item_id>/checkout", methods=["POST"])

--- a/templates/lockbox_add.html
+++ b/templates/lockbox_add.html
@@ -2,48 +2,14 @@
 {% block title %}Add Lockbox - KBM{% endblock %}
 
 {% block content %}
-<style>
-  .form-card .select-field {
-    position: relative;
-  }
-  .form-card .select-field select {
-    appearance: none;
-    width: 100%;
-    padding: 12px 44px 12px 14px;
-    border-radius: 12px;
-    border: 1px solid var(--color-border);
-    background: linear-gradient(135deg, rgba(148, 163, 184, 0.08), rgba(148, 163, 184, 0.02));
-    color: var(--color-text);
-    font-size: 14px;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  }
-  .form-card .select-field select:focus {
-    outline: none;
-    border-color: var(--color-accent);
-    box-shadow: 0 0 0 3px var(--color-accent-soft);
-    background: linear-gradient(135deg, rgba(229, 57, 53, 0.12), rgba(148, 163, 184, 0.05));
-  }
-  .form-card .select-field select option {
-    background: var(--color-card);
-    color: var(--color-text);
-    padding: 8px;
-  }
-  .form-card .select-field::after {
-    content: "\25BC";
-    position: absolute;
-    top: 50%;
-    right: 14px;
-    transform: translateY(-50%);
-    font-size: 12px;
-    pointer-events: none;
-    color: var(--color-muted);
-  }
-</style>
-
 <div class="form-shell">
   <h2>Add Lockbox</h2>
+  <p class="muted text-small" style="margin-top: -6px;">
+    Property assignment happens after the lockbox exists — open the lockbox's
+    detail page and click Edit to attach it to a property.
+  </p>
   <form method="post" action="{{ url_for('inventory.add_lockbox') }}" class="card form-card">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <div class="form-field">
       <label for="label">Label *</label>
       <input id="label" type="text" name="label" required placeholder="LB-001">
@@ -54,25 +20,15 @@
     </div>
     <div class="form-field">
       <label for="supra_id">Supra ID</label>
-      <input id="supra_id" type="text" name="supra_id" placeholder="Optional - for Supra lockboxes">
+      <input id="supra_id" type="text" name="supra_id" placeholder="Optional — for Supra lockboxes">
     </div>
     <div class="form-field">
       <label for="location">Location</label>
       <input id="location" type="text" name="location" placeholder="Front desk">
     </div>
-    <div class="form-field select-field">
-      <label for="property_id">Property</label>
-      <select id="property_id" name="property_id">
-        <option value="">-- Select Property --</option>
-        {% for prop in properties %}
-          <option value="{{ prop.id }}">{{ prop.display }}</option>
-        {% endfor %}
-      </select>
-      <small class="muted">Optional. Address will auto-fill when left blank.</small>
-    </div>
     <div class="form-field">
       <label for="address">Address</label>
-      <input id="address" type="text" name="address" placeholder="123 Main St">
+      <input id="address" type="text" name="address" placeholder="Optional — fill in if you already know where it'll go">
     </div>
 
     <div class="toolbar align-end">
@@ -81,28 +37,4 @@
     </div>
   </form>
 </div>
-
-<script>
-  (function() {
-    const propertyLookup = {{ property_lookup|default({})|tojson }};
-    const propertySelect = document.getElementById('property_id');
-    const addressInput = document.getElementById('address');
-
-    propertySelect.addEventListener('change', () => {
-      const details = propertyLookup[propertySelect.value] || null;
-      if (!details) {
-        return;
-      }
-      if (!addressInput.value) {
-        const parts = [
-          details.address_line1,
-          details.city,
-          details.state,
-          details.postal_code
-        ];
-        addressInput.value = parts.filter(Boolean).join(', ');
-      }
-    });
-  })();
-</script>
 {% endblock %}


### PR DESCRIPTION
## What

The Add Lockbox form no longer asks for a Property — that step happens later via the lockbox's detail page (Edit modal). Keeps the create form focused on the physical lockbox: label, code, supra id, location, address.

## Why

Matches how the workflow tends to go in practice: a lockbox arrives at the office before you know which property it'll go on. Forcing a property up front turned a 30-second add into a "do I have to set up the property first?" detour.

## Scope of change

- \`templates/lockbox_add.html\`: dropped the Property select, the JS that auto-filled the address from the picked property, and the now-unused \`.select-field\` CSS block. Added a one-line note so users aren't surprised the field is missing.
- \`inventory/views.py:add_lockbox\`: removed the property-loading query, \`property_choices\`/\`property_lookup\` building, property_id form parsing, and the property_id meta entry on the activity log.
- Edit-lockbox is unchanged — it still accepts \`property_id\`, so the existing edit modal at \`/item/<id>\` remains the place to wire a lockbox to a property.
- Success flash text now hints at the next step: "Lockbox added. Open the lockbox to assign it to a property."

## Test plan
- [ ] Visit Add Lockbox → no Property select; only Label / Code / Supra ID / Location / Address fields.
- [ ] Submit → success flash mentions opening the lockbox to assign a property.
- [ ] Open the new lockbox's detail page → Edit → property picker still works there.
- [ ] Existing lockboxes' property assignments are untouched.