### PR TITLE
Fix lockbox row buttons: script-order bug

### DIFF
--- a/templates/lockboxes.html
+++ b/templates/lockboxes.html
@@ -557,9 +557,9 @@
   </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/modals.js') }}"></script>
-<script src="{{ url_for('static', filename='js/item_actions.js') }}"></script>
 <script>
+  // Must be set BEFORE item_actions.js loads — that script is an IIFE
+  // that reads window.kbmItemDetails on parse and bails out if missing.
   window.kbmItemDetails = {
     itemType: 'lockbox',
     statusOptions: {{ status_options | tojson }},
@@ -568,5 +568,6 @@
     activeCheckoutsUrl: null
   };
 </script>
+<script src="{{ url_for('static', filename='js/item_actions.js') }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

Lockbox row buttons (Edit / Check Out / Check In / Assign) shipped in #38 don't actually fire on click. Root cause is a script-order bug in `templates/lockboxes.html`:

- `item_actions.js` is an IIFE that reads `window.kbmItemDetails` at parse time
- If that global is `undefined`, the early-return guard fires and **zero handlers are bound**
- The template loaded `item_actions.js` *before* the inline `<script>` that defines `window.kbmItemDetails` — so on every page load the IIFE bailed out silently and clicks did nothing

Fix: move the inline `<script>` defining `window.kbmItemDetails` above the `<script src=".../item_actions.js">` tag, matching the order already used (and working) in `templates/item_details.html`.

Also drop the dead `static/js/modals.js` `<script>` tag — that file doesn't exist in the repo, so it 404'd on every list-page load. Modal CSS lives in `base.html` and `item_actions.js` handles its own modal show/hide.

## Test plan

- [ ] Deploy and reload `/lockboxes`
- [ ] Click **Edit** on any row → modal opens with current values pre-filled, save persists
- [ ] On a row with status `available`, click **Check Out** → modal opens, submit checks the lockbox out and returns to the list
- [ ] On a row with status `assigned` or `checked_out`, click **Check In** → modal opens, submit checks it in and returns to the list
- [ ] Click **Assign** → modal opens, submit assigns and returns to the list
- [ ] Browser console shows no 404 for `modals.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)