### PR TITLE
Import wizard: fuzzy matching, dup handling, in-flow property creation

### DIFF
--- a/inventory/import_views.py
+++ b/inventory/import_views.py
@@ -3,8 +3,10 @@
 from flask import render_template, request, redirect, url_for, flash, jsonify, session
 from flask_login import login_required, current_user
 import csv
+import difflib
 import io
-from typing import List, Dict, Any, Optional
+from collections import OrderedDict
+from typing import List, Dict, Any, Optional, Tuple
 from werkzeug.utils import secure_filename
 
 from utilities.tenant_helpers import tenant_query, tenant_add, tenant_commit, tenant_rollback, get_tenant_session
@@ -14,6 +16,628 @@ from . import inventory_bp
 
 
 ALLOWED_EXTENSIONS = {'csv', 'xlsx', 'xls'}
+
+# Max rows we'll keep in the session for an import. Beyond this we slice +
+# warn the user; sessions get expensive past a few hundred KB.
+MAX_IMPORT_ROWS = 1000
+
+# difflib similarity cutoff for fuzzy property/unit name matches. 0.85 keeps
+# typos ("Smith Apartment" vs "Smith Apartments") and rejects abbreviations
+# ("Smith Apts"). Tighter is safer for incorrect assignments.
+FUZZY_MATCH_CUTOFF = 0.85
+
+# Cap on per-row warnings flashed at the end of an import. Anything beyond
+# this is summarized as "...and N more".
+MAX_WARNINGS_DISPLAYED = 10
+
+
+# ---- Fuzzy matching helpers --------------------------------------------------
+
+def _normalize(s) -> str:
+    """Trim + lowercase. Used for case-insensitive equality before fuzzy matching."""
+    if s is None:
+        return ''
+    return str(s).strip().lower()
+
+
+def _fuzzy_find_property(name: str, all_properties) -> Tuple[Optional[Property], bool]:
+    """Find a Property by name. Returns (property, is_fuzzy_match).
+
+    Tries exact case-insensitive match (after stripping) first, falls back to
+    fuzzy match against the cutoff. Returns (None, False) if no match.
+    """
+    target = _normalize(name)
+    if not target:
+        return None, False
+
+    by_norm_name = {}
+    for prop in all_properties:
+        key = _normalize(prop.name)
+        if key and key not in by_norm_name:
+            by_norm_name[key] = prop
+
+    exact = by_norm_name.get(target)
+    if exact is not None:
+        return exact, False
+
+    matches = difflib.get_close_matches(target, list(by_norm_name.keys()), n=1, cutoff=FUZZY_MATCH_CUTOFF)
+    if matches:
+        return by_norm_name[matches[0]], True
+    return None, False
+
+
+def _fuzzy_find_unit(label: str, units) -> Tuple[Optional[PropertyUnit], bool]:
+    """Find a PropertyUnit by label within a given property's units."""
+    target = _normalize(label)
+    if not target:
+        return None, False
+
+    by_norm_label = {}
+    for unit in units:
+        key = _normalize(unit.label)
+        if key and key not in by_norm_label:
+            by_norm_label[key] = unit
+
+    exact = by_norm_label.get(target)
+    if exact is not None:
+        return exact, False
+
+    matches = difflib.get_close_matches(target, list(by_norm_label.keys()), n=1, cutoff=FUZZY_MATCH_CUTOFF)
+    if matches:
+        return by_norm_label[matches[0]], True
+    return None, False
+
+
+def _similarity_pct(a: str, b: str) -> int:
+    """Rough integer percent similarity for UI display."""
+    return int(difflib.SequenceMatcher(None, _normalize(a), _normalize(b)).ratio() * 100)
+
+
+def _flash_warning_summary(warnings: List[str]) -> None:
+    """Flash up to MAX_WARNINGS_DISPLAYED individual warnings + a summary."""
+    if not warnings:
+        return
+    visible = warnings[:MAX_WARNINGS_DISPLAYED]
+    extra = len(warnings) - len(visible)
+    for w in visible:
+        flash(w, "warning")
+    if extra > 0:
+        flash(f"...and {extra} more import warning(s) suppressed.", "warning")
+
+
+# ---- Import analysis (pre-resolution) ----------------------------------------
+
+def _analyze_import(rows: List[Dict[str, str]], mapping: Dict[str, str], item_type_canonical: str) -> Dict[str, Any]:
+    """Inspect a parsed file to power the resolve/review wizard.
+
+    Performs:
+      - In-file dedup by label (first occurrence wins; subsequent dropped).
+      - Cross-tenant duplicate check by label against existing items of this type.
+      - Property name classification (exact / fuzzy / missing).
+
+    Returns a dict of summarized data the resolve template renders. Unit
+    handling is deferred to the process step (where it's gated on the
+    auto-create-units checkbox + whether the resolved property is brand new).
+
+    item_type_canonical: 'Key' | 'Lockbox' | 'Sign' (matches Item.type values)
+    """
+    label_col = mapping.get('label')
+    property_col = mapping.get('property_name')
+    address_col = mapping.get('address')
+
+    # In-file dedup by label
+    seen_labels = {}
+    deduped = []
+    in_file_dups = []  # list of (row_idx, label, dropped_because_dup_of_row)
+
+    for idx, row in enumerate(rows, 1):
+        label = (row.get(label_col, '') or '').strip() if label_col else ''
+        if not label:
+            # blank labels handled in process step (counted as errors there)
+            deduped.append((idx, row))
+            continue
+        norm = _normalize(label)
+        first_idx = seen_labels.get(norm)
+        if first_idx is not None:
+            in_file_dups.append((idx, label, first_idx))
+            continue
+        seen_labels[norm] = idx
+        deduped.append((idx, row))
+
+    # Existing tenant items of this type — for duplicate detection
+    existing_items = tenant_query(Item).filter(Item.type == item_type_canonical).all()
+    existing_by_label = {}
+    for item in existing_items:
+        key = _normalize(item.label)
+        if key and key not in existing_by_label:
+            existing_by_label[key] = item
+
+    duplicates = []
+    for idx, row in deduped:
+        label = (row.get(label_col, '') or '').strip() if label_col else ''
+        if not label:
+            continue
+        existing = existing_by_label.get(_normalize(label))
+        if existing:
+            duplicates.append({
+                'row_idx': idx,
+                'label': label,
+                'existing_id': existing.id,
+                'existing_label': existing.label,
+            })
+
+    # Properties classification
+    all_properties = tenant_query(Property).all()
+    property_options = sorted([(p.id, p.name) for p in all_properties], key=lambda x: x[1].lower())
+
+    unique_property_names = OrderedDict()
+    if property_col:
+        for idx, row in deduped:
+            name = (row.get(property_col, '') or '').strip()
+            if not name:
+                continue
+            if name not in unique_property_names:
+                addr = (row.get(address_col, '') or '').strip() if address_col else ''
+                unique_property_names[name] = {
+                    'sample_address': addr or None,
+                    'first_row_idx': idx,
+                }
+
+    property_resolution = []
+    for name, meta in unique_property_names.items():
+        prop, is_fuzzy = _fuzzy_find_property(name, all_properties)
+        entry = {
+            'name': name,
+            'sample_address': meta['sample_address'],
+            'first_row_idx': meta['first_row_idx'],
+        }
+        if prop and not is_fuzzy:
+            entry['status'] = 'exact'
+            entry['matched_property_id'] = prop.id
+            entry['matched_property_name'] = prop.name
+        elif prop and is_fuzzy:
+            entry['status'] = 'fuzzy'
+            entry['matched_property_id'] = prop.id
+            entry['matched_property_name'] = prop.name
+            entry['similarity'] = _similarity_pct(name, prop.name)
+        else:
+            entry['status'] = 'missing'
+            entry['matched_property_id'] = None
+            entry['matched_property_name'] = None
+        property_resolution.append(entry)
+
+    needs_property_review = sum(1 for p in property_resolution if p['status'] in ('fuzzy', 'missing'))
+    exact_property_matches = sum(1 for p in property_resolution if p['status'] == 'exact')
+
+    # "Ready" rows: not duplicate, and either no property_name or exact match
+    duplicate_row_idxs = {d['row_idx'] for d in duplicates}
+    needs_review_property_names = {
+        p['name'] for p in property_resolution if p['status'] in ('fuzzy', 'missing')
+    }
+    ready_count = 0
+    for idx, row in deduped:
+        if idx in duplicate_row_idxs:
+            continue
+        prop_name = (row.get(property_col, '') or '').strip() if property_col else ''
+        if prop_name and prop_name in needs_review_property_names:
+            continue
+        ready_count += 1
+
+    return {
+        'rows': deduped,
+        'in_file_dups': in_file_dups,
+        'duplicates': duplicates,
+        'properties': property_resolution,
+        'property_options': property_options,
+        'stats': {
+            'total_rows_in_file': len(rows),
+            'in_file_dup_count': len(in_file_dups),
+            'unique_after_dedup': len(deduped),
+            'duplicate_count': len(duplicates),
+            'exact_property_matches': exact_property_matches,
+            'needs_property_review': needs_property_review,
+            'ready_count': ready_count,
+        },
+    }
+
+
+# ---- Resolution application (post-user-choice) -------------------------------
+
+def _apply_property_resolutions(
+    properties_resolution: List[Dict[str, Any]],
+    user_actions: Dict[str, str],
+    all_properties_by_id: Dict[int, Property],
+) -> Tuple[Dict[str, Optional[Property]], List[Property], List[str]]:
+    """Build a name -> Property (or None) map per the user's choices.
+
+    Returns (name_to_property, newly_created_properties, warnings).
+
+    user_actions: dict keyed by property_name from the resolution list. Values:
+        - "create_new"
+        - "use_existing:<property_id>"
+        - "skip"
+        (For 'exact' entries, no action key is needed — auto-applied.)
+    """
+    name_to_property: Dict[str, Optional[Property]] = {}
+    newly_created: List[Property] = []
+    warnings: List[str] = []
+
+    for p in properties_resolution:
+        name = p['name']
+        status = p['status']
+
+        if status == 'exact':
+            existing = all_properties_by_id.get(p['matched_property_id'])
+            name_to_property[name] = existing
+            continue
+
+        action = (user_actions.get(name) or '').strip()
+        if not action:
+            # Default for fuzzy = use the suggestion; default for missing = skip.
+            action = 'use_existing:%d' % p['matched_property_id'] if status == 'fuzzy' else 'skip'
+
+        if action == 'create_new':
+            address = (p.get('sample_address') or '').strip() or '(set after import)'
+            new_prop = Property(
+                name=name,
+                address_line1=address,
+                type='single_family',
+            )
+            tenant_add(new_prop)
+            try:
+                get_tenant_session().flush()
+            except Exception as exc:
+                warnings.append(f"Could not create property '{name}': {exc}")
+                name_to_property[name] = None
+                continue
+            newly_created.append(new_prop)
+            name_to_property[name] = new_prop
+            if not p.get('sample_address'):
+                warnings.append(
+                    f"Created property '{name}' with placeholder address — please update it on the property page."
+                )
+        elif action.startswith('use_existing:'):
+            try:
+                prop_id = int(action.split(':', 1)[1])
+            except (ValueError, IndexError):
+                prop_id = None
+            chosen = all_properties_by_id.get(prop_id) if prop_id else None
+            name_to_property[name] = chosen
+            if chosen is None:
+                warnings.append(f"Could not resolve selection for property '{name}' — left unassigned.")
+        else:
+            # 'skip' / unknown -> leave unassigned
+            name_to_property[name] = None
+
+    return name_to_property, newly_created, warnings
+
+
+def _resolve_unit_for_row(
+    property_obj: Optional[Property],
+    unit_label: str,
+    is_property_newly_created: bool,
+    auto_create_units: bool,
+    units_cache: Dict[int, Dict[str, PropertyUnit]],
+    row_idx: int,
+) -> Tuple[Optional[PropertyUnit], List[str]]:
+    """Resolve a single row's unit. Returns (unit, warnings).
+
+    Auto-creates units for brand-new properties unconditionally. For existing
+    properties, only auto-creates if the auto_create_units checkbox was on.
+    """
+    warnings: List[str] = []
+    label = (unit_label or '').strip()
+
+    if not label:
+        return None, warnings
+
+    if property_obj is None:
+        warnings.append(
+            f"Row {row_idx}: unit '{label}' could not be assigned (no resolved property) — left unassigned."
+        )
+        return None, warnings
+
+    cache = units_cache.setdefault(property_obj.id, {})
+    if not cache:
+        # Lazy-load units the first time we see this property
+        for u in tenant_query(PropertyUnit).filter(PropertyUnit.property_id == property_obj.id).all():
+            key = _normalize(u.label)
+            if key:
+                cache[key] = u
+
+    norm = _normalize(label)
+    existing = cache.get(norm)
+    if existing is not None:
+        return existing, warnings
+
+    # Try fuzzy
+    fuzzy_unit, is_fuzzy = _fuzzy_find_unit(label, list(cache.values()))
+    if fuzzy_unit is not None:
+        warnings.append(
+            f"Row {row_idx}: unit '{label}' fuzzy-matched to '{fuzzy_unit.label}' on '{property_obj.name}'."
+        )
+        return fuzzy_unit, warnings
+
+    # No match — auto-create or warn
+    should_create = is_property_newly_created or auto_create_units
+    if should_create:
+        new_unit = PropertyUnit(property_id=property_obj.id, label=label)
+        tenant_add(new_unit)
+        try:
+            get_tenant_session().flush()
+        except Exception as exc:
+            warnings.append(f"Row {row_idx}: could not create unit '{label}' on '{property_obj.name}': {exc}")
+            return None, warnings
+        cache[norm] = new_unit
+        if not is_property_newly_created:
+            warnings.append(
+                f"Row {row_idx}: unit '{label}' created on existing property '{property_obj.name}'."
+            )
+        return new_unit, warnings
+
+    warnings.append(
+        f"Row {row_idx}: unit '{label}' did not match any unit on '{property_obj.name}' — left unassigned."
+    )
+    return None, warnings
+
+
+def _extract_item_data(row: Dict[str, str], mapping: Dict[str, str], fields: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Convert a single CSV row into a dict of import-controlled field values."""
+    item_data: Dict[str, Any] = {}
+    label_col = mapping.get('label')
+    label = (row.get(label_col, '') or '').strip() if label_col else ''
+    item_data['label'] = label
+
+    for field_name, config in fields.items():
+        if field_name == 'label':
+            continue
+        column = mapping.get(field_name)
+        if not column:
+            if 'default' in config:
+                item_data[field_name] = config['default']
+            continue
+        value = (row.get(column, '') or '').strip()
+        if not value:
+            if 'default' in config:
+                item_data[field_name] = config['default']
+            continue
+        if config.get('type') == 'int':
+            try:
+                item_data[field_name] = int(value)
+            except (ValueError, TypeError):
+                item_data[field_name] = config.get('default', 0)
+        else:
+            item_data[field_name] = value
+    return item_data
+
+
+def _parse_resolution_form(
+    form,
+    properties_resolution: List[Dict[str, Any]],
+    duplicates: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Pull user choices out of the resolve form."""
+    property_actions: Dict[str, str] = {}
+    for idx, p in enumerate(properties_resolution):
+        if p['status'] == 'exact':
+            continue
+        action = (form.get(f'prop_action_{idx}') or '').strip()
+        if action == 'use_existing':
+            chosen_id = (form.get(f'prop_existing_{idx}') or '').strip()
+            if chosen_id:
+                action = f'use_existing:{chosen_id}'
+        property_actions[p['name']] = action
+
+    duplicate_actions: Dict[int, str] = {}
+    for idx, d in enumerate(duplicates):
+        action = (form.get(f'dup_action_{idx}') or 'skip').strip()
+        duplicate_actions[d['row_idx']] = action
+
+    auto_create_units = (form.get('auto_create_units') or '').lower() in ('1', 'true', 'on', 'yes')
+
+    return {
+        'property_actions': property_actions,
+        'duplicate_actions': duplicate_actions,
+        'auto_create_units': auto_create_units,
+    }
+
+
+def _run_resolved_import(
+    *,
+    analysis: Dict[str, Any],
+    mapping: Dict[str, str],
+    fields: Dict[str, Dict[str, Any]],
+    item_type_canonical: str,
+    user_choices: Dict[str, Any],
+    custom_id_factory,                # callable(item_data: dict) -> str
+) -> Dict[str, Any]:
+    """Execute an import once the user has resolved properties + duplicates.
+
+    Returns a dict with counts and a warnings list.
+    """
+    rows = analysis['rows']                # [(row_idx, row_dict), ...]
+    properties_resolution = analysis['properties']
+    duplicates = analysis['duplicates']
+
+    auto_create_units = user_choices['auto_create_units']
+    property_actions = user_choices['property_actions']
+    duplicate_actions = user_choices['duplicate_actions']
+
+    # Pre-load tenant data
+    all_properties = tenant_query(Property).all()
+    all_properties_by_id: Dict[int, Property] = {p.id: p for p in all_properties}
+
+    name_to_property, newly_created, prop_warnings = _apply_property_resolutions(
+        properties_resolution, property_actions, all_properties_by_id,
+    )
+    newly_created_ids = {p.id for p in newly_created}
+
+    # Pre-load existing items by id for duplicate updates/replaces
+    existing_ids_needed = {d['existing_id'] for d in duplicates}
+    existing_items_by_id: Dict[int, Item] = {}
+    if existing_ids_needed:
+        existing_items_by_id = {
+            item.id: item
+            for item in tenant_query(Item)
+                .filter(Item.id.in_(existing_ids_needed))
+                .all()
+        }
+    duplicate_lookup: Dict[int, Dict[str, Any]] = {d['row_idx']: d for d in duplicates}
+
+    units_cache: Dict[int, Dict[str, PropertyUnit]] = {}
+
+    counts = {
+        'created': 0,
+        'updated': 0,
+        'replaced': 0,
+        'skipped_duplicate': 0,
+        'skipped_blank_label': 0,
+        'failed': 0,
+    }
+    warnings: List[str] = list(prop_warnings)
+
+    # In-file dedup notice
+    in_file_dups = analysis.get('in_file_dups') or []
+    if in_file_dups:
+        sample = ', '.join(f"row {r} ({lbl})" for r, lbl, _ in in_file_dups[:5])
+        more = '' if len(in_file_dups) <= 5 else f" (+{len(in_file_dups)-5} more)"
+        warnings.append(
+            f"{len(in_file_dups)} duplicate label(s) within the file were skipped: {sample}{more}"
+        )
+
+    for idx, row in rows:
+        try:
+            item_data = _extract_item_data(row, mapping, fields)
+            label = item_data.get('label', '').strip()
+            if not label:
+                counts['skipped_blank_label'] += 1
+                warnings.append(f"Row {idx}: blank label — skipped.")
+                continue
+
+            property_name = item_data.pop('property_name', None)
+            property_unit_label = item_data.pop('property_unit_label', None)
+
+            property_obj = name_to_property.get(property_name) if property_name else None
+            is_newly_created_prop = bool(property_obj and property_obj.id in newly_created_ids)
+
+            unit_obj, unit_warnings = _resolve_unit_for_row(
+                property_obj=property_obj,
+                unit_label=property_unit_label or '',
+                is_property_newly_created=is_newly_created_prop,
+                auto_create_units=auto_create_units,
+                units_cache=units_cache,
+                row_idx=idx,
+            )
+            warnings.extend(unit_warnings)
+
+            dup = duplicate_lookup.get(idx)
+            if dup:
+                action = duplicate_actions.get(idx, 'skip')
+                existing = existing_items_by_id.get(dup['existing_id'])
+                if existing is None:
+                    # Fell out from under us between analysis and apply.
+                    warnings.append(
+                        f"Row {idx}: duplicate target missing for '{label}' — skipped."
+                    )
+                    counts['skipped_duplicate'] += 1
+                    continue
+
+                if action == 'skip':
+                    counts['skipped_duplicate'] += 1
+                    continue
+
+                if action == 'update':
+                    # Merge: only set non-empty values from the row.
+                    for field_name, value in item_data.items():
+                        if value in (None, ''):
+                            continue
+                        if hasattr(existing, field_name):
+                            setattr(existing, field_name, value)
+                    if property_obj is not None:
+                        existing.property_id = property_obj.id
+                    if unit_obj is not None:
+                        existing.property_unit_id = unit_obj.id
+                    existing.last_action = 'updated'
+                    existing.last_action_at = utc_now()
+                    existing.last_action_by_id = current_user.id if current_user.is_authenticated else None
+                    counts['updated'] += 1
+                    continue
+
+                if action == 'replace':
+                    # Overwrite mapped columns only. Empty cells in a mapped
+                    # column blank out the existing value (this is the
+                    # difference from "update"). Unmapped columns stay
+                    # untouched — Replace doesn't wipe fields the user
+                    # never expressed an opinion about.
+                    for field_name, config in fields.items():
+                        if field_name in ('property_name', 'property_unit_label'):
+                            continue
+                        if field_name not in mapping:
+                            continue
+                        if field_name in item_data:
+                            setattr(existing, field_name, item_data[field_name])
+                        else:
+                            # Mapped column but empty cell: blank out (or
+                            # fall back to declared default for fields like
+                            # status which is nullable=False).
+                            default = config.get('default', None)
+                            setattr(existing, field_name, default)
+                    if 'property_name' in mapping:
+                        existing.property_id = property_obj.id if property_obj else None
+                    if 'property_unit_label' in mapping:
+                        existing.property_unit_id = unit_obj.id if unit_obj else None
+                    existing.last_action = 'updated'
+                    existing.last_action_at = utc_now()
+                    existing.last_action_by_id = current_user.id if current_user.is_authenticated else None
+                    counts['replaced'] += 1
+                    continue
+
+                # Unknown action — treat as skip
+                counts['skipped_duplicate'] += 1
+                continue
+
+            # New item
+            new_item = Item(
+                type=item_type_canonical,
+                custom_id=custom_id_factory(item_data),
+                property_id=property_obj.id if property_obj else None,
+                property_unit_id=unit_obj.id if unit_obj else None,
+                last_action='added',
+                last_action_at=utc_now(),
+                last_action_by_id=current_user.id if current_user.is_authenticated else None,
+                **item_data,
+            )
+            tenant_add(new_item)
+            counts['created'] += 1
+
+        except Exception as exc:
+            counts['failed'] += 1
+            warnings.append(f"Row {idx}: {exc}")
+
+    return {'counts': counts, 'warnings': warnings}
+
+
+def _flash_import_summary(counts: Dict[str, int], item_type_plural: str) -> None:
+    """Compose the final result flash."""
+    parts = []
+    if counts['created']:
+        parts.append(f"Imported {counts['created']:,} new")
+    if counts['updated']:
+        parts.append(f"updated {counts['updated']:,}")
+    if counts['replaced']:
+        parts.append(f"replaced {counts['replaced']:,}")
+    if counts['skipped_duplicate']:
+        parts.append(f"skipped {counts['skipped_duplicate']:,} duplicate(s)")
+    if counts['skipped_blank_label']:
+        parts.append(f"skipped {counts['skipped_blank_label']:,} blank-label row(s)")
+    if counts['failed']:
+        parts.append(f"failed {counts['failed']:,}")
+
+    msg_type = 'success' if (counts['created'] or counts['updated'] or counts['replaced']) else 'warning'
+    if parts:
+        flash(f"{item_type_plural}: " + ' · '.join(parts) + '.', msg_type)
+    else:
+        flash(f"No {item_type_plural.lower()} were imported.", 'warning')
 
 
 def allowed_file(filename):
@@ -144,12 +768,22 @@ def import_keys():
                 flash("File is empty or could not be parsed", "error")
                 return redirect(request.url)
 
-            # Store in session for column mapping
+            # Cap the rows we keep in the session. Past MAX_IMPORT_ROWS we'd
+            # blow session size for cookie-based stores.
+            total_rows = len(rows)
+            kept_rows = rows[:MAX_IMPORT_ROWS]
+            if total_rows > MAX_IMPORT_ROWS:
+                flash(
+                    f"File has {total_rows:,} rows; only the first {MAX_IMPORT_ROWS:,} "
+                    "will be imported. Split larger files and re-upload to import the rest.",
+                    "warning",
+                )
+
             session['import_data'] = {
                 'headers': headers,
-                'rows': rows[:100],  # Limit preview to 100 rows
-                'total_rows': len(rows),
-                'file_type': 'keys'
+                'rows': kept_rows,
+                'total_rows': total_rows,
+                'file_type': 'keys',
             }
 
             return redirect(url_for('inventory.import_keys_map'))
@@ -200,7 +834,13 @@ def import_keys_map():
 @login_required
 @tenant_required
 def import_keys_process():
-    """Process the import with mapped columns"""
+    """Resolve duplicates + properties, then import.
+
+    GET: render the resolve wizard with classified rows, duplicates, and
+         properties needing user attention.
+    POST: re-analyze (cheap), apply user decisions, run the import, redirect
+          back to the list with a summary flash.
+    """
     import_data = session.get('import_data')
     mapping = session.get('import_mapping')
 
@@ -208,121 +848,46 @@ def import_keys_process():
         flash("Import session expired. Please start over.", "error")
         return redirect(url_for('inventory.import_keys'))
 
+    rows = import_data['rows']
+
     if request.method == "POST":
-        rows = import_data['rows']
-        created_count = 0
-        error_count = 0
-        errors = []
-
-        for idx, row in enumerate(rows, 1):
-            try:
-                # Extract data using mapping
-                label = row.get(mapping.get('label', ''), '').strip()
-                if not label:
-                    error_count += 1
-                    errors.append(f"Row {idx}: Label is required")
-                    continue
-
-                # Build item data
-                item_data = {'label': label}
-
-                for field_name, config in KEY_FIELDS.items():
-                    if field_name == 'label':
-                        continue
-
-                    column = mapping.get(field_name)
-                    if not column:
-                        # Use default if available
-                        if 'default' in config:
-                            item_data[field_name] = config['default']
-                        continue
-
-                    value = row.get(column, '').strip()
-                    if not value:
-                        if 'default' in config:
-                            item_data[field_name] = config['default']
-                        continue
-
-                    # Type conversion
-                    if config.get('type') == 'int':
-                        try:
-                            item_data[field_name] = int(value)
-                        except ValueError:
-                            item_data[field_name] = config.get('default', 0)
-                    else:
-                        item_data[field_name] = value
-
-                # Handle property lookup
-                property_obj = None
-                property_unit_obj = None
-
-                property_name = item_data.pop('property_name', None)
-                property_unit_label = item_data.pop('property_unit_label', None)
-
-                if property_name:
-                    property_obj = tenant_query(Property).filter(
-                        Property.name.ilike(property_name)
-                    ).first()
-
-                if property_unit_label and property_obj:
-                    property_unit_obj = tenant_query(PropertyUnit).filter(
-                        PropertyUnit.property_id == property_obj.id,
-                        PropertyUnit.label.ilike(property_unit_label)
-                    ).first()
-
-                # Create item
-                key = Item(
-                    type="Key",
-                    custom_id=Item.generate_custom_id("Key"),
-                    property_id=property_obj.id if property_obj else None,
-                    property_unit_id=property_unit_obj.id if property_unit_obj else None,
-                    last_action="added",
-                    last_action_at=utc_now(),
-                    last_action_by_id=current_user.id if current_user.is_authenticated else None,
-                    **item_data
-                )
-
-                tenant_add(key)
-                created_count += 1
-
-            except Exception as e:
-                error_count += 1
-                errors.append(f"Row {idx}: {str(e)}")
+        analysis = _analyze_import(rows, mapping, 'Key')
+        user_choices = _parse_resolution_form(request.form, analysis['properties'], analysis['duplicates'])
 
         try:
+            result = _run_resolved_import(
+                analysis=analysis,
+                mapping=mapping,
+                fields=KEY_FIELDS,
+                item_type_canonical='Key',
+                user_choices=user_choices,
+                custom_id_factory=lambda item_data: Item.generate_custom_id('Key'),
+            )
             tenant_commit()
-            flash(f"Successfully imported {created_count} keys", "success")
-            if error_count > 0:
-                flash(f"{error_count} rows had errors", "warning")
-
-            # Clear session data
-            session.pop('import_data', None)
-            session.pop('import_mapping', None)
-
-            return redirect(url_for('inventory.list_keys'))
-
-        except Exception as e:
+        except Exception as exc:
             tenant_rollback()
-            flash(f"Database error: {str(e)}", "error")
+            flash(f"Database error: {exc}", "error")
             return redirect(url_for('inventory.import_keys'))
 
-    # Show preview
-    preview_rows = import_data['rows'][:10]
-    preview_data = []
+        _flash_import_summary(result['counts'], 'Keys')
+        _flash_warning_summary(result['warnings'])
 
-    for row in preview_rows:
-        preview_item = {}
-        for field_name, column in mapping.items():
-            preview_item[field_name] = row.get(column, '')
-        preview_data.append(preview_item)
+        session.pop('import_data', None)
+        session.pop('import_mapping', None)
+        return redirect(url_for('inventory.list_keys'))
 
+    # GET — render the resolve wizard
+    analysis = _analyze_import(rows, mapping, 'Key')
     return render_template(
-        "import_preview.html",
-        preview_data=preview_data,
-        total_rows=import_data['total_rows'],
-        fields=KEY_FIELDS,
+        "import_resolve.html",
+        analysis=analysis,
         mapping=mapping,
-        item_type="Keys"
+        fields=KEY_FIELDS,
+        item_type="Keys",
+        item_type_singular="Key",
+        process_url=url_for('inventory.import_keys_process'),
+        cancel_url=url_for('inventory.import_keys'),
+        back_url=url_for('inventory.import_keys_map'),
     )
 
 
@@ -362,12 +927,20 @@ def import_lockboxes():
                 flash("File is empty or could not be parsed", "error")
                 return redirect(request.url)
 
-            # Store in session for column mapping
+            total_rows = len(rows)
+            kept_rows = rows[:MAX_IMPORT_ROWS]
+            if total_rows > MAX_IMPORT_ROWS:
+                flash(
+                    f"File has {total_rows:,} rows; only the first {MAX_IMPORT_ROWS:,} "
+                    "will be imported. Split larger files and re-upload to import the rest.",
+                    "warning",
+                )
+
             session['import_data'] = {
                 'headers': headers,
-                'rows': rows[:100],  # Limit preview to 100 rows
-                'total_rows': len(rows),
-                'file_type': 'lockboxes'
+                'rows': kept_rows,
+                'total_rows': total_rows,
+                'file_type': 'lockboxes',
             }
 
             return redirect(url_for('inventory.import_lockboxes_map'))
@@ -418,7 +991,7 @@ def import_lockboxes_map():
 @login_required
 @tenant_required
 def import_lockboxes_process():
-    """Process the import with mapped columns"""
+    """Resolve duplicates + properties, then import lockboxes."""
     import_data = session.get('import_data')
     mapping = session.get('import_mapping')
 
@@ -426,121 +999,45 @@ def import_lockboxes_process():
         flash("Import session expired. Please start over.", "error")
         return redirect(url_for('inventory.import_lockboxes'))
 
+    rows = import_data['rows']
+
     if request.method == "POST":
-        rows = import_data['rows']
-        created_count = 0
-        error_count = 0
-        errors = []
-
-        for idx, row in enumerate(rows, 1):
-            try:
-                # Extract data using mapping
-                label = row.get(mapping.get('label', ''), '').strip()
-                if not label:
-                    error_count += 1
-                    errors.append(f"Row {idx}: Label is required")
-                    continue
-
-                # Build item data
-                item_data = {'label': label}
-
-                for field_name, config in LOCKBOX_FIELDS.items():
-                    if field_name == 'label':
-                        continue
-
-                    column = mapping.get(field_name)
-                    if not column:
-                        # Use default if available
-                        if 'default' in config:
-                            item_data[field_name] = config['default']
-                        continue
-
-                    value = row.get(column, '').strip()
-                    if not value:
-                        if 'default' in config:
-                            item_data[field_name] = config['default']
-                        continue
-
-                    # Type conversion
-                    if config.get('type') == 'int':
-                        try:
-                            item_data[field_name] = int(value)
-                        except ValueError:
-                            item_data[field_name] = config.get('default', 0)
-                    else:
-                        item_data[field_name] = value
-
-                # Handle property lookup
-                property_obj = None
-                property_unit_obj = None
-
-                property_name = item_data.pop('property_name', None)
-                property_unit_label = item_data.pop('property_unit_label', None)
-
-                if property_name:
-                    property_obj = tenant_query(Property).filter(
-                        Property.name.ilike(property_name)
-                    ).first()
-
-                if property_unit_label and property_obj:
-                    property_unit_obj = tenant_query(PropertyUnit).filter(
-                        PropertyUnit.property_unit_id == property_obj.id,
-                        PropertyUnit.label.ilike(property_unit_label)
-                    ).first()
-
-                # Create item
-                lockbox = Item(
-                    type="Lockbox",
-                    custom_id=Item.generate_custom_id("Lockbox"),
-                    property_id=property_obj.id if property_obj else None,
-                    property_unit_id=property_unit_obj.id if property_unit_obj else None,
-                    last_action="added",
-                    last_action_at=utc_now(),
-                    last_action_by_id=current_user.id if current_user.is_authenticated else None,
-                    **item_data
-                )
-
-                tenant_add(lockbox)
-                created_count += 1
-
-            except Exception as e:
-                error_count += 1
-                errors.append(f"Row {idx}: {str(e)}")
+        analysis = _analyze_import(rows, mapping, 'Lockbox')
+        user_choices = _parse_resolution_form(request.form, analysis['properties'], analysis['duplicates'])
 
         try:
+            result = _run_resolved_import(
+                analysis=analysis,
+                mapping=mapping,
+                fields=LOCKBOX_FIELDS,
+                item_type_canonical='Lockbox',
+                user_choices=user_choices,
+                custom_id_factory=lambda item_data: Item.generate_custom_id('Lockbox'),
+            )
             tenant_commit()
-            flash(f"Successfully imported {created_count} lockboxes", "success")
-            if error_count > 0:
-                flash(f"{error_count} rows had errors", "warning")
-
-            # Clear session data
-            session.pop('import_data', None)
-            session.pop('import_mapping', None)
-
-            return redirect(url_for('inventory.list_lockboxes'))
-
-        except Exception as e:
+        except Exception as exc:
             tenant_rollback()
-            flash(f"Database error: {str(e)}", "error")
+            flash(f"Database error: {exc}", "error")
             return redirect(url_for('inventory.import_lockboxes'))
 
-    # Show preview
-    preview_rows = import_data['rows'][:10]
-    preview_data = []
+        _flash_import_summary(result['counts'], 'Lockboxes')
+        _flash_warning_summary(result['warnings'])
 
-    for row in preview_rows:
-        preview_item = {}
-        for field_name, column in mapping.items():
-            preview_item[field_name] = row.get(column, '')
-        preview_data.append(preview_item)
+        session.pop('import_data', None)
+        session.pop('import_mapping', None)
+        return redirect(url_for('inventory.list_lockboxes'))
 
+    analysis = _analyze_import(rows, mapping, 'Lockbox')
     return render_template(
-        "import_preview.html",
-        preview_data=preview_data,
-        total_rows=import_data['total_rows'],
-        fields=LOCKBOX_FIELDS,
+        "import_resolve.html",
+        analysis=analysis,
         mapping=mapping,
-        item_type="Lockboxes"
+        fields=LOCKBOX_FIELDS,
+        item_type="Lockboxes",
+        item_type_singular="Lockbox",
+        process_url=url_for('inventory.import_lockboxes_process'),
+        cancel_url=url_for('inventory.import_lockboxes'),
+        back_url=url_for('inventory.import_lockboxes_map'),
     )
 
 
@@ -580,11 +1077,20 @@ def import_signs():
                 flash("File is empty or could not be parsed", "error")
                 return redirect(request.url)
 
-            # Store in session
+            total_rows = len(rows)
+            kept_rows = rows[:MAX_IMPORT_ROWS]
+            if total_rows > MAX_IMPORT_ROWS:
+                flash(
+                    f"File has {total_rows:,} rows; only the first {MAX_IMPORT_ROWS:,} "
+                    "will be imported. Split larger files and re-upload to import the rest.",
+                    "warning",
+                )
+
             session['import_data'] = {
                 'headers': headers,
-                'rows': rows[:1000],  # Limit to first 1000 rows
-                'total_rows': len(rows)
+                'rows': kept_rows,
+                'total_rows': total_rows,
+                'file_type': 'signs',
             }
 
             return redirect(url_for('inventory.import_signs_map'))
@@ -635,7 +1141,7 @@ def import_signs_map():
 @login_required
 @tenant_required
 def import_signs_process():
-    """Preview and process sign import"""
+    """Resolve duplicates + properties, then import signs."""
     import_data = session.get('import_data')
     mapping = session.get('import_mapping')
 
@@ -643,105 +1149,43 @@ def import_signs_process():
         flash("Missing import data. Please start the import process again.", "error")
         return redirect(url_for('inventory.import_signs'))
 
+    rows = import_data['rows']
+
     if request.method == "POST":
-        # Perform the actual import
-        created_count = 0
-        skipped_count = 0
-        errors = []
+        analysis = _analyze_import(rows, mapping, 'Sign')
+        user_choices = _parse_resolution_form(request.form, analysis['properties'], analysis['duplicates'])
 
         try:
-            for idx, row in enumerate(import_data['rows']):
-                # Get label (required)
-                label_column = mapping.get('label')
-                label = str(row.get(label_column, '')).strip() if label_column else ''
-
-                if not label:
-                    skipped_count += 1
-                    continue
-
-                # Build item data
-                item_data = {'label': label}
-
-                for field_name, config in SIGN_FIELDS.items():
-                    if field_name == 'label':
-                        continue
-
-                    column = mapping.get(field_name)
-                    if not column:
-                        # Use default if available
-                        if 'default' in config:
-                            item_data[field_name] = config['default']
-                        continue
-
-                    value = str(row.get(column, '')).strip() if row.get(column) is not None else ''
-                    if value:
-                        item_data[field_name] = value
-                    elif 'default' in config:
-                        item_data[field_name] = config['default']
-
-                # Handle property and unit mapping
-                property_obj = None
-                property_unit_obj = None
-
-                property_name = item_data.pop('property_name', None)
-                if property_name:
-                    property_obj = tenant_query(Property).filter(
-                        db.func.lower(Property.name) == property_name.lower()
-                    ).first()
-
-                property_unit_label = item_data.pop('property_unit_label', None)
-                if property_obj and property_unit_label:
-                    property_unit_obj = tenant_query(PropertyUnit).filter(
-                        PropertyUnit.property_id == property_obj.id,
-                        db.func.lower(PropertyUnit.label) == property_unit_label.lower()
-                    ).first()
-
-                # Create sign
-                new_sign = Item(
-                    type='Sign',
-                    **item_data
-                )
-
-                if property_obj:
-                    new_sign.property_id = property_obj.id
-                if property_unit_obj:
-                    new_sign.property_unit_id = property_unit_obj.id
-
-                # Generate custom ID
-                new_sign.custom_id = Item.generate_custom_id('Sign', item_data.get('sign_subtype'))
-
-                tenant_add(new_sign)
-                created_count += 1
-
+            result = _run_resolved_import(
+                analysis=analysis,
+                mapping=mapping,
+                fields=SIGN_FIELDS,
+                item_type_canonical='Sign',
+                user_choices=user_choices,
+                custom_id_factory=lambda item_data: Item.generate_custom_id('Sign', item_data.get('sign_subtype')),
+            )
             tenant_commit()
-            flash(f"Successfully imported {created_count} signs. Skipped {skipped_count} rows.", "success")
-
-            # Clear session data
-            session.pop('import_data', None)
-            session.pop('import_mapping', None)
-
-            return redirect(url_for('inventory.list_signs'))
-
-        except Exception as e:
+        except Exception as exc:
             tenant_rollback()
-            flash(f"Database error: {str(e)}", "error")
+            flash(f"Database error: {exc}", "error")
             return redirect(url_for('inventory.import_signs'))
 
-    # Show preview
-    preview_rows = import_data['rows'][:10]
-    preview_data = []
+        _flash_import_summary(result['counts'], 'Signs')
+        _flash_warning_summary(result['warnings'])
 
-    for row in preview_rows:
-        preview_item = {}
-        for field_name, column in mapping.items():
-            preview_item[field_name] = row.get(column, '')
-        preview_data.append(preview_item)
+        session.pop('import_data', None)
+        session.pop('import_mapping', None)
+        return redirect(url_for('inventory.list_signs'))
 
+    analysis = _analyze_import(rows, mapping, 'Sign')
     return render_template(
-        "import_preview.html",
-        preview_data=preview_data,
-        total_rows=import_data['total_rows'],
-        fields=SIGN_FIELDS,
+        "import_resolve.html",
+        analysis=analysis,
         mapping=mapping,
-        item_type="Signs"
+        fields=SIGN_FIELDS,
+        item_type="Signs",
+        item_type_singular="Sign",
+        process_url=url_for('inventory.import_signs_process'),
+        cancel_url=url_for('inventory.import_signs'),
+        back_url=url_for('inventory.import_signs_map'),
     )

--- a/templates/import_resolve.html
+++ b/templates/import_resolve.html
@@ -1,0 +1,377 @@
+{% extends "base.html" %}
+{% block title %}Review Import - {{ item_type }} - KBM{% endblock %}
+
+{% block content %}
+{# This template renders the resolve/review wizard between column mapping
+   and the actual import. Server-side analysis hands us:
+     - analysis.stats: counts for the summary card
+     - analysis.duplicates: rows that match existing tenant items by label
+     - analysis.properties: unique property names with status (exact|fuzzy|missing)
+     - analysis.property_options: [(id, name)] for the "use existing" dropdown
+   The form posts back to process_url where _parse_resolution_form picks up
+   the user's decisions. #}
+
+{% set stats = analysis.stats %}
+{% set duplicates = analysis.duplicates %}
+{% set properties = analysis.properties %}
+{% set property_options = analysis.property_options %}
+
+<style>
+  .resolve-shell { max-width: 1100px; margin: 0 auto; }
+  .stats-card {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+  .stat-tile {
+    padding: 14px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    background: var(--color-card);
+  }
+  .stat-tile .label {
+    display: block;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-muted);
+    margin-bottom: 6px;
+  }
+  .stat-tile .value {
+    font-size: 24px;
+    font-weight: 600;
+  }
+  .stat-tile.success { background: rgba(74, 222, 128, 0.06); border-color: rgba(74, 222, 128, 0.3); }
+  .stat-tile.warning { background: rgba(251, 191, 36, 0.06); border-color: rgba(251, 191, 36, 0.3); }
+  .stat-tile.danger  { background: rgba(229, 57, 53, 0.06); border-color: rgba(229, 57, 53, 0.3); }
+
+  .resolve-section {
+    margin-bottom: 28px;
+    padding: 18px;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-card);
+  }
+  .resolve-section h2 {
+    margin: 0 0 8px 0;
+    font-size: 18px;
+  }
+  .resolve-section .muted-note {
+    color: var(--color-muted);
+    font-size: 13px;
+    margin: 0 0 14px 0;
+  }
+  .bulk-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px 12px;
+    margin-bottom: 14px;
+    border-radius: 8px;
+    background: rgba(148, 163, 184, 0.06);
+    border: 1px solid var(--color-border);
+  }
+  .bulk-bar .label { font-size: 13px; align-self: center; margin-right: 8px; color: var(--color-muted); }
+
+  .resolve-row {
+    padding: 12px 14px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    margin-bottom: 10px;
+    background: rgba(148, 163, 184, 0.03);
+  }
+  .resolve-row .row-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .resolve-row .row-detail {
+    font-size: 13px;
+    color: var(--color-muted);
+    margin-bottom: 10px;
+  }
+  .resolve-row .options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    align-items: center;
+  }
+  .resolve-row .options label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 14px;
+  }
+  .resolve-row .options select {
+    padding: 4px 6px;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: var(--color-card);
+    color: var(--color-text);
+    font-size: 13px;
+  }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .badge.fuzzy   { background: rgba(251, 191, 36, 0.16); color: #fbbf24; }
+  .badge.missing { background: rgba(229, 57, 53, 0.16); color: #f87171; }
+  .badge.dup     { background: rgba(96, 165, 250, 0.16); color: #60a5fa; }
+
+  .empty-note {
+    padding: 14px;
+    color: var(--color-muted);
+    font-style: italic;
+    text-align: center;
+  }
+
+  .footer-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    padding: 16px;
+    border-top: 1px solid var(--color-border);
+    margin-top: 12px;
+  }
+  .footer-actions .spacer { flex: 1; }
+</style>
+
+<div class="resolve-shell">
+  <div class="page-header">
+    <h1>Review Import — {{ item_type }}</h1>
+    <p class="muted">
+      Review duplicates and unmatched property names before importing.
+      {% if stats.exact_property_matches %}
+        {{ stats.exact_property_matches }} property name(s) matched existing properties exactly and will be linked automatically.
+      {% endif %}
+    </p>
+  </div>
+
+  <div class="stats-card">
+    <div class="stat-tile success">
+      <span class="label">Ready to import</span>
+      <span class="value">{{ stats.ready_count }}</span>
+    </div>
+    <div class="stat-tile {{ 'warning' if stats.duplicate_count else '' }}">
+      <span class="label">Duplicates to review</span>
+      <span class="value">{{ stats.duplicate_count }}</span>
+    </div>
+    <div class="stat-tile {{ 'warning' if stats.needs_property_review else '' }}">
+      <span class="label">Properties to review</span>
+      <span class="value">{{ stats.needs_property_review }}</span>
+    </div>
+    {% if stats.in_file_dup_count %}
+      <div class="stat-tile danger">
+        <span class="label">In-file duplicates skipped</span>
+        <span class="value">{{ stats.in_file_dup_count }}</span>
+      </div>
+    {% endif %}
+    <div class="stat-tile">
+      <span class="label">Total rows in file</span>
+      <span class="value">{{ stats.total_rows_in_file }}</span>
+    </div>
+  </div>
+
+  <form method="post" action="{{ process_url }}" id="resolve-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+    {# ---- Duplicates section ---- #}
+    <section class="resolve-section">
+      <h2>Duplicates ({{ duplicates|length }})</h2>
+      <p class="muted-note">
+        These rows have a label that matches an existing {{ item_type|lower }} in your account.
+        Choose what to do for each — or use the bulk actions below.
+        <strong>Update</strong> overlays only non-empty fields from the file onto the existing record.
+        <strong>Replace</strong> overwrites every imported field, blanking out fields you didn't supply.
+        <strong>Skip</strong> leaves the existing record untouched.
+      </p>
+
+      {% if duplicates %}
+        <div class="bulk-bar">
+          <span class="label">Bulk:</span>
+          <button type="button" class="btn small" data-bulk="dup" data-value="skip">Skip all</button>
+          <button type="button" class="btn small" data-bulk="dup" data-value="update">Update all</button>
+          <button type="button" class="btn small" data-bulk="dup" data-value="replace">Replace all</button>
+        </div>
+
+        {% for d in duplicates %}
+          <div class="resolve-row">
+            <div class="row-title">
+              <span class="badge dup">Duplicate</span>
+              Row {{ d.row_idx }}: "{{ d.label }}"
+            </div>
+            <div class="row-detail">
+              already exists in your {{ item_type|lower }} (existing label: "{{ d.existing_label }}")
+            </div>
+            <div class="options">
+              <label>
+                <input type="radio" name="dup_action_{{ loop.index0 }}" value="skip" checked>
+                Skip
+              </label>
+              <label>
+                <input type="radio" name="dup_action_{{ loop.index0 }}" value="update">
+                Update (merge non-empty fields)
+              </label>
+              <label>
+                <input type="radio" name="dup_action_{{ loop.index0 }}" value="replace">
+                Replace (overwrite all fields)
+              </label>
+            </div>
+          </div>
+        {% endfor %}
+      {% else %}
+        <div class="empty-note">No duplicates detected.</div>
+      {% endif %}
+    </section>
+
+    {# ---- Properties section ---- #}
+    <section class="resolve-section">
+      <h2>Property Review ({{ properties|selectattr('status', 'in', ['fuzzy', 'missing'])|list|length }})</h2>
+      <p class="muted-note">
+        These property names from your file don't match an existing property exactly.
+        Choose to use a fuzzy-matched property, pick a different existing one, create a new property,
+        or leave the row's property unassigned.
+      </p>
+
+      {% set review_props = properties|selectattr('status', 'in', ['fuzzy', 'missing'])|list %}
+      {% if review_props %}
+        <div class="bulk-bar">
+          <span class="label">Bulk:</span>
+          <button type="button" class="btn small" data-bulk="prop-fuzzy" data-value="use_existing">Accept all fuzzy matches</button>
+          <button type="button" class="btn small" data-bulk="prop-missing" data-value="create_new">Create all missing</button>
+          <button type="button" class="btn small" data-bulk="prop" data-value="skip">Leave all unassigned</button>
+        </div>
+
+        {% for p in properties %}
+          {% if p.status in ('fuzzy', 'missing') %}
+            <div class="resolve-row" data-prop-status="{{ p.status }}">
+              <div class="row-title">
+                {% if p.status == 'fuzzy' %}
+                  <span class="badge fuzzy">Fuzzy {{ p.similarity }}%</span>
+                {% else %}
+                  <span class="badge missing">No match</span>
+                {% endif %}
+                "{{ p.name }}"
+              </div>
+              <div class="row-detail">
+                {% if p.status == 'fuzzy' %}
+                  Suggested: <strong>{{ p.matched_property_name }}</strong>
+                  {% if p.sample_address %}
+                    · file address: {{ p.sample_address }}
+                  {% endif %}
+                {% else %}
+                  Not found in your existing properties
+                  {% if p.sample_address %}
+                    · file address: {{ p.sample_address }}
+                  {% endif %}
+                {% endif %}
+                · first seen on row {{ p.first_row_idx }}
+              </div>
+              <div class="options">
+                <label>
+                  <input type="radio" name="prop_action_{{ loop.index0 }}" value="use_existing"
+                         {% if p.status == 'fuzzy' %}checked{% endif %}>
+                  {% if p.status == 'fuzzy' %}Use existing:{% else %}Pick existing:{% endif %}
+                  <select name="prop_existing_{{ loop.index0 }}" class="prop-existing-select">
+                    <option value="">-- select --</option>
+                    {% for opt_id, opt_name in property_options %}
+                      <option value="{{ opt_id }}"
+                              {% if p.status == 'fuzzy' and opt_id == p.matched_property_id %}selected{% endif %}>
+                        {{ opt_name }}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </label>
+                <label>
+                  <input type="radio" name="prop_action_{{ loop.index0 }}" value="create_new"
+                         {% if p.status == 'missing' %}checked{% endif %}>
+                  Create new "{{ p.name }}"
+                </label>
+                <label>
+                  <input type="radio" name="prop_action_{{ loop.index0 }}" value="skip">
+                  Leave unassigned
+                </label>
+              </div>
+            </div>
+          {% endif %}
+        {% endfor %}
+      {% else %}
+        <div class="empty-note">All property names matched existing properties exactly.</div>
+      {% endif %}
+    </section>
+
+    {# ---- Auto-create units toggle ---- #}
+    <section class="resolve-section">
+      <h2>Units</h2>
+      <p class="muted-note">
+        Units on <em>newly-created</em> properties are auto-created from the file's unit labels.
+        Toggle below to also auto-create units on existing properties when an unmatched unit label appears.
+      </p>
+      <label style="display: inline-flex; gap: 8px; align-items: center; cursor: pointer;">
+        <input type="checkbox" name="auto_create_units" value="on">
+        Auto-create missing units for existing properties (off by default — safer)
+      </label>
+    </section>
+
+    <div class="footer-actions">
+      <a class="btn ghost" href="{{ cancel_url }}">Cancel</a>
+      <a class="btn ghost" href="{{ back_url }}">Back to mapping</a>
+      <span class="spacer"></span>
+      <button type="submit" class="btn primary">Confirm &amp; Import</button>
+    </div>
+  </form>
+</div>
+
+<script>
+(function () {
+  // Bulk-action handlers
+  document.querySelectorAll('[data-bulk]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var bulkType = btn.dataset.bulk;
+      var value = btn.dataset.value;
+      var rows;
+
+      if (bulkType === 'dup') {
+        rows = document.querySelectorAll('input[type="radio"][name^="dup_action_"]');
+        rows.forEach(function (r) {
+          if (r.value === value) r.checked = true;
+        });
+      } else if (bulkType === 'prop') {
+        rows = document.querySelectorAll('input[type="radio"][name^="prop_action_"]');
+        rows.forEach(function (r) {
+          if (r.value === value) r.checked = true;
+        });
+      } else if (bulkType === 'prop-fuzzy') {
+        // Use the fuzzy suggestion (use_existing radio + the pre-selected dropdown value)
+        document.querySelectorAll('.resolve-row[data-prop-status="fuzzy"]').forEach(function (row) {
+          var radio = row.querySelector('input[type="radio"][value="use_existing"]');
+          if (radio) radio.checked = true;
+        });
+      } else if (bulkType === 'prop-missing') {
+        document.querySelectorAll('.resolve-row[data-prop-status="missing"]').forEach(function (row) {
+          var radio = row.querySelector('input[type="radio"][value="create_new"]');
+          if (radio) radio.checked = true;
+        });
+      }
+    });
+  });
+
+  // When user picks from the "use existing" dropdown, auto-check the use_existing radio
+  document.querySelectorAll('.prop-existing-select').forEach(function (sel) {
+    sel.addEventListener('change', function () {
+      if (!sel.value) return;
+      var name = sel.name.replace('prop_existing_', 'prop_action_');
+      var radio = document.querySelector('input[type="radio"][name="' + name + '"][value="use_existing"]');
+      if (radio) radio.checked = true;
+    });
+  });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Replaces the post-mapping preview step for keys/lockboxes/signs with a **review wizard** that handles every case the old flow swallowed silently. Adds fuzzy property/unit matching, duplicate detection with skip/update/replace, in-flow property creation, and a 100→1000 row cap raise.

## Highlights

### Property resolution
- **Exact matches** → auto-linked, count shown in summary card
- **Fuzzy matches** (≥85% similarity, conservative cutoff) → defaulted to suggestion with a dropdown to pick differently
- **No match** → defaulted to "create new" with options to pick existing or skip
- **Bulk actions:** "Accept all fuzzy matches" · "Create all missing" · "Leave all unassigned"
- New properties use the row's `address` column for `address_line1` (required NOT NULL), or a placeholder + warning

### Units
- Auto-created on **newly-created** properties (no extra clicks)
- Unmatched units on **existing** properties → unassigned + warn, unless `Auto-create missing units for existing properties` is toggled on (off by default for safety)

### Duplicate handling (NEW)
Detects existing tenant items by exact (case-insensitive, trimmed) label match within the same item type:
- **Skip** (default) — leave existing alone, drop the row
- **Update** — overlay non-empty fields from the row onto existing record
- **Replace** — overwrite *mapped* columns only (empty cells in mapped columns blank the field; unmapped columns untouched). Audit history (`id`, `custom_id`, `last_action_*`, checkout history) preserved.
- **In-file duplicates** (same label twice in the upload) → first-occurrence wins; rest dropped silently with a final warning.

### Bug fixes folded in
- **Lockbox import FK typo** — `PropertyUnit.property_unit_id` (column doesn't exist) → `PropertyUnit.property_id`. Was throwing `AttributeError` on every import row that had both property name + unit label.
- **Silent 100-row cap** on keys + lockboxes — raised to 1000 (matches signs); files larger than the cap flash a warning at upload now.

### Final summary flash
> Keys: Imported 47 new · updated 3 · replaced 1 · skipped 2 duplicate(s) · failed 0.

Plus up to 10 individual warnings + "...and N more" overflow.

## Architecture

Three near-identical process functions collapsed into thin wrappers around shared helpers:

- `_analyze_import` — in-file dedup, duplicate detection, property classification
- `_apply_property_resolutions` — creates new properties as needed, builds `name → Property` map
- `_resolve_unit_for_row` — exact / fuzzy / auto-create cascade with caching
- `_run_resolved_import` — applies user choices, creates / updates / replaces items, returns counts + warnings
- `_extract_item_data`, `_parse_resolution_form`, `_flash_import_summary`, `_flash_warning_summary`

## Test plan

- [ ] **Keys import — happy path:** upload a CSV with new + existing properties, exact + fuzzy + missing names, including duplicates. Verify the wizard shows correct stats, duplicate options work (skip/update/replace), and final flash matches actual results.
- [ ] **Lockbox property+unit import:** confirm the FK-typo bug is gone — rows with both property_name and property_unit_label should resolve cleanly without per-row AttributeError.
- [ ] **Auto-create units toggle:** verify off → unmatched units stay unassigned with warning; on → new units created on existing properties.
- [ ] **Newly-created property auto-units:** confirm units auto-create when the row's property is brand new.
- [ ] **Replace semantics:** replace a duplicate with a row that has only label + keycode mapped. Confirm only those mapped fields change; other fields untouched.
- [ ] **Update semantics:** update a duplicate with a row containing some empty cells. Confirm empty cells don't clobber existing values.
- [ ] **In-file dup warning:** upload a file with two rows having the same label. Confirm only the first imports + warning fires.
- [ ] **>1000 row file:** upload a 1500-row file. Confirm "first 1000 will be imported" warning + actual cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)