### PR TITLE
Traefik support: routing labels + opt-in compose override

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -14,7 +14,8 @@ PYTHONUNBUFFERED=1
 # Generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=__GENERATE_ME__
 
-# Shared secret used by Caddy to authenticate against the app's
+# Shared secret used by Caddy's on_demand_tls.ask OR Traefik's
+# forwardauth middleware to authenticate against the app's
 # /_internal/check-domain endpoint. Generate with the same command above.
 INTERNAL_API_SECRET=__GENERATE_ME__
 
@@ -31,6 +32,21 @@ ACME_EMAIL=admin@buywithvesta.com
 # Detected by install_vps.sh via: getent group docker | cut -d: -f3
 # Used by compose.yaml `group_add` so the container can use the host docker socket.
 DOCKER_GID=999
+
+# --- Optional: reverse-proxy choice ---
+# Default: compose.yaml — Caddy with on-demand TLS via ask endpoint.
+# Alternative: append compose.traefik.yaml to switch to Traefik. Compose
+# merges both files, disables caddy via an unused profile, and adds traefik.
+# See TRAEFIK.md for trade-offs and the DNS-01 wildcard option.
+#
+# To use Traefik instead, uncomment the line below:
+# COMPOSE_FILE=compose.yaml:compose.traefik.yaml
+
+# --- Optional: Traefik DNS-01 wildcard support ---
+# Only used when COMPOSE_FILE includes compose.traefik.yaml AND you've
+# edited traefik/traefik.yml to enable the dnsChallenge block. See TRAEFIK.md.
+# Example: Cloudflare API token with Zone:DNS:Edit on the BASE_DOMAIN zone.
+# CLOUDFLARE_DNS_API_TOKEN=
 
 # --- App settings ---
 # Multi-tenant mode does not use a single DATABASE_URI. Each tenant has its own

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,9 @@ credentials/
 *.pem
 *.crt
 *.p12
+
+# Traefik cert state — contains private keys for issued Let's Encrypt certs.
+# The traefik/letsencrypt/ directory itself is kept (with .gitkeep) so the
+# bind mount target exists, but acme.json never gets committed.
+traefik/letsencrypt/acme.json
+traefik/letsencrypt/*.json

--- a/TRAEFIK.md
+++ b/TRAEFIK.md
@@ -1,0 +1,131 @@
+# Traefik support
+
+KBM ships with **Caddy** as the default reverse proxy. **Traefik v3** is a
+drop-in alternative — same routing, same Let's Encrypt cert issuance, same
+multi-tenant subdomain gating via `/_internal/check-domain`.
+
+You pick which proxy runs by setting `COMPOSE_FILE` in `.env`:
+
+```
+# Default (Caddy) — no setting needed
+# COMPOSE_FILE is unset, docker compose uses compose.yaml only.
+
+# Switch to Traefik:
+COMPOSE_FILE=compose.yaml:compose.traefik.yaml
+```
+
+Compose merges both files when both are listed. `compose.traefik.yaml`
+disables Caddy (puts it behind an unused profile) and defines a `traefik`
+service. The python-app service keeps its Traefik labels from `compose.yaml`
+regardless of which proxy runs — they're inert under Caddy.
+
+## Why you might want Traefik instead of Caddy
+
+You wouldn't, for most setups. Caddy's `on_demand_tls.ask` mechanism is
+genuinely nice for multi-tenant. Pick Traefik when:
+
+- You already run Traefik for other apps and want one proxy across them.
+- You need a feature Traefik has and Caddy doesn't (advanced middlewares,
+  Prometheus metrics, specific cert provider).
+- You want a DNS-01 **wildcard cert** for `*.${BASE_DOMAIN}` instead of
+  per-subdomain HTTP-01 certs (see below).
+
+## Switching from Caddy to Traefik
+
+On your VPS:
+
+1. Pull the latest code.
+2. Edit `.env`, uncomment the line:
+   ```
+   COMPOSE_FILE=compose.yaml:compose.traefik.yaml
+   ```
+3. `docker compose -p kbm down` (cleanly stops Caddy).
+4. `docker compose -p kbm up -d` (starts python-app + Traefik).
+5. Browse to your root domain. Watch `docker logs traefik -f` on the first
+   hit — you should see an ACME challenge fire and a cert get issued.
+
+To switch back to Caddy: comment out `COMPOSE_FILE`, then `down` + `up -d`
+again.
+
+## Cert challenge: HTTP-01 vs DNS-01 wildcard
+
+Out of the box `traefik/traefik.yml` is configured for the **HTTP-01**
+challenge. This works without any DNS provider creds, but Traefik issues
+**one cert per unique subdomain** that hits the proxy. Let's Encrypt's
+hard limit is 50 certs per registered domain per week.
+
+The `tenant-gate` forwardauth middleware (defined as a label on
+`python-app` in `compose.yaml`) gates per-request authorization — returns
+401 for subdomains that don't map to active tenants. **It doesn't gate
+cert issuance** — Traefik will still attempt LE for any subdomain that
+resolves to your VPS and hits port 443. An attacker controlling a
+wildcard DNS record pointed at your IP could exhaust your rate limit.
+
+For a public multi-tenant production deployment, **switch to DNS-01 with
+a wildcard cert** covering `*.${BASE_DOMAIN}`. One cert covers all
+current and future tenants. No per-subdomain issuance, no rate-limit risk.
+
+### Enabling DNS-01 wildcard (Cloudflare example)
+
+1. Move your DNS to Cloudflare (or any provider supported by lego/Traefik).
+   Create an API token with `Zone:DNS:Edit` on the `BASE_DOMAIN` zone.
+2. Add to `.env`:
+   ```
+   CLOUDFLARE_DNS_API_TOKEN=<your token>
+   ```
+3. Edit `traefik/traefik.yml`. Replace the `httpChallenge:` block under
+   `certificatesResolvers.letsencrypt.acme` with:
+   ```yaml
+   dnsChallenge:
+     provider: cloudflare
+     resolvers:
+       - "1.1.1.1:53"
+       - "8.8.8.8:53"
+   ```
+4. Edit `compose.traefik.yaml`, add an `environment:` block to the
+   `traefik` service:
+   ```yaml
+   environment:
+     - CLOUDFLARE_DNS_API_TOKEN=${CLOUDFLARE_DNS_API_TOKEN}
+   ```
+5. `docker compose -p kbm restart traefik`. Watch the logs — Traefik will
+   request a wildcard cert via DNS-01 challenge.
+
+For other providers (Route 53, Hetzner, DigitalOcean, etc.), see
+<https://doc.traefik.io/traefik/https/acme/#providers>. Each provider
+needs slightly different env vars.
+
+## How the routing labels work
+
+Every router rule lives as a label on the `python-app` service in
+`compose.yaml`. They're inert when Caddy is the proxy (Caddy doesn't read
+Docker labels), and active when Traefik runs.
+
+- `kbm-root` router → matches `BASE_DOMAIN` and `www.BASE_DOMAIN` exactly.
+- `kbm-tenants` router → matches any single-level subdomain via
+  `HostRegexp(`^[a-z0-9-]+\.${BASE_DOMAIN}$`)`. Per-request gated by the
+  `tenant-gate@docker` middleware (forwardauth → `/_internal/check-domain`).
+
+The `/_internal/check-domain` endpoint reads the candidate host from:
+
+1. `?domain=` query param (Caddy's `on_demand_tls.ask` passes this way)
+2. `X-Forwarded-Host` header (Traefik forwardauth populates this)
+3. `Host` header (fallback)
+
+Same endpoint, both proxies, no code branching.
+
+## Files added by this feature
+
+```
+compose.traefik.yaml         — Override file that swaps Caddy → Traefik
+traefik/traefik.yml          — Traefik v3 static config (entrypoints, providers, cert resolver)
+traefik/letsencrypt/         — Bind-mount target for acme.json (cert state)
+                                acme.json itself is .gitignored
+TRAEFIK.md                   — This file
+```
+
+## Backward compatibility
+
+Existing deploys with `.env` files that don't set `COMPOSE_FILE` continue
+to use `compose.yaml` exactly as before. The new Traefik labels on the
+python-app service are inert under Caddy. No migration steps needed.

--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -164,11 +164,20 @@ def create_app():
     def health():
         return {"ok": True, "multi_tenant": True}, 200
 
-    # 9a) Caddy on-demand TLS validation endpoint.
-    # Caddy calls this before issuing a Let's Encrypt cert for a subdomain.
-    # Returns 200 if the requested host maps to an active tenant (or is the
-    # configured root domain), 404 otherwise. A shared secret prevents abuse
-    # if the endpoint is ever exposed beyond the internal docker network.
+    # 9a) On-demand TLS / per-request tenant validation endpoint.
+    # Two callers, two flows — same endpoint:
+    #
+    #   - Caddy uses this as its `on_demand_tls.ask` BEFORE issuing a cert
+    #     for a subdomain. Caddy passes the candidate hostname as ?domain=.
+    #     Returns 200 if the host maps to an active tenant (or is the root
+    #     domain), 404 otherwise.
+    #
+    #   - Traefik uses this as a `forwardauth` middleware on EVERY request
+    #     to a tenant subdomain (gates the request, not the cert). Traefik
+    #     passes the original Host as X-Forwarded-Host. Same response logic.
+    #
+    # A shared INTERNAL_API_SECRET prevents abuse if the endpoint is ever
+    # exposed beyond the internal docker network.
     @app.get("/_internal/check-domain")
     def _check_domain():
         from utilities.master_database import Account
@@ -179,7 +188,17 @@ def create_app():
         if not expected_secret or provided != expected_secret:
             return {"ok": False, "reason": "unauthorized"}, 403
 
+        # Resolve the candidate domain in priority order:
+        #   1) ?domain=  (Caddy's on_demand_tls.ask passes it this way)
+        #   2) X-Forwarded-Host header (Traefik forwardauth populates this
+        #      with the original Host of the gated request)
+        #   3) Host header (last-resort fallback if a future proxy doesn't
+        #      forward the original host)
         domain = (_req.args.get("domain", "") or "").lower().strip()
+        if not domain:
+            domain = (_req.headers.get("X-Forwarded-Host", "") or "").lower().strip().split(":")[0]
+        if not domain:
+            domain = (_req.host or "").lower().strip().split(":")[0]
         if not domain:
             return {"ok": False, "reason": "missing-domain"}, 400
 

--- a/compose.traefik.yaml
+++ b/compose.traefik.yaml
@@ -1,0 +1,41 @@
+# Compose override file that swaps Caddy for Traefik. Apply by setting
+# COMPOSE_FILE in .env:
+#
+#     COMPOSE_FILE=compose.yaml:compose.traefik.yaml
+#
+# Compose merges both files — the python-app service keeps its labels from
+# compose.yaml (which Traefik now picks up), and:
+#   - caddy gets `profiles: ["disabled"]` so it never starts
+#   - traefik service gets added
+#
+# To switch back to Caddy: remove the override from COMPOSE_FILE in .env
+# and `docker compose up -d` again.
+
+services:
+  caddy:
+    # Putting caddy behind an arbitrary profile that never gets activated
+    # is the standard Compose-override pattern for "disable this service".
+    # The actual port/volume/image config stays untouched, just inert.
+    profiles: ["disabled"]
+
+  traefik:
+    image: traefik:v3.1
+    container_name: traefik
+    restart: unless-stopped
+    init: true
+    env_file:
+      - .env
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/letsencrypt:/letsencrypt
+      # Read-only docker socket — Traefik only needs to *read* container
+      # labels, never write back. :ro is a small additional defense if
+      # anything ever compromised the Traefik container.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - python-app
+    networks:
+      - appnet

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,6 +50,43 @@ services:
       - ./middleware:/app/middleware
     networks:
       - appnet
+    # Traefik routing labels. Inert when Caddy is the proxy (Caddy ignores
+    # them). Picked up automatically when Traefik runs in this same compose
+    # network — either via the `traefik` profile below or via an external
+    # Traefik instance pointed at this docker socket.
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=appnet"
+
+      # Backend service definition (one for all routers below)
+      - "traefik.http.services.kbm-app.loadbalancer.server.port=8000"
+
+      # ---- Router: root domain + www (explicit Host rule, eager cert) ----
+      - "traefik.http.routers.kbm-root.rule=Host(`${BASE_DOMAIN}`) || Host(`www.${BASE_DOMAIN}`)"
+      - "traefik.http.routers.kbm-root.entrypoints=websecure"
+      - "traefik.http.routers.kbm-root.tls=true"
+      - "traefik.http.routers.kbm-root.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.kbm-root.service=kbm-app"
+
+      # ---- Router: wildcard tenant subdomains ----
+      # Uses HostRegexp (Traefik v3 Go-regex syntax). The cert resolver
+      # decides whether each unique subdomain gets its own HTTP-01 cert,
+      # or whether they all share a DNS-01 wildcard cert covering
+      # *.${BASE_DOMAIN} (recommended for production multi-tenant). See
+      # traefik/traefik.yml + TRAEFIK.md for the choice.
+      - "traefik.http.routers.kbm-tenants.rule=HostRegexp(`^[a-z0-9-]+\\.${BASE_DOMAIN}$`)"
+      - "traefik.http.routers.kbm-tenants.entrypoints=websecure"
+      - "traefik.http.routers.kbm-tenants.tls=true"
+      - "traefik.http.routers.kbm-tenants.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.kbm-tenants.tls.domains[0].main=${BASE_DOMAIN}"
+      - "traefik.http.routers.kbm-tenants.tls.domains[0].sans=*.${BASE_DOMAIN}"
+      - "traefik.http.routers.kbm-tenants.service=kbm-app"
+      # Per-request gating via the same /_internal/check-domain endpoint
+      # Caddy uses. Even with HTTP-01 (per-subdomain certs), requests for
+      # subdomains that don't map to active tenants get 401'd here.
+      - "traefik.http.routers.kbm-tenants.middlewares=tenant-gate@docker"
+      - "traefik.http.middlewares.tenant-gate.forwardauth.address=http://python-app:8000/_internal/check-domain?secret=${INTERNAL_API_SECRET}"
+      - "traefik.http.middlewares.tenant-gate.forwardauth.trustForwardHeader=true"
 
   caddy:
     image: caddy:2-alpine

--- a/deploy/install_vps.sh
+++ b/deploy/install_vps.sh
@@ -86,6 +86,7 @@ if grep -q "^DOCKER_GID=" .env; then
 	fi
 fi
 
+
 # ------------------------------------------------------------------------------
 # 4. Required directories (gitignored, so won't exist on a fresh clone)
 # ------------------------------------------------------------------------------
@@ -95,7 +96,7 @@ APP_UID=1000
 APP_GID=1000
 
 log "Ensuring data directories exist"
-mkdir -p master_db tenant_dbs backups logs uploads
+mkdir -p master_db tenant_dbs backups logs uploads traefik/letsencrypt
 
 # Chown the entire repo to appuser. This covers:
 #   - data dirs (master_db, tenant_dbs, backups, logs)

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,74 @@
+# Traefik v3 static configuration for KBM.
+# Loaded by the `traefik` service in compose.yaml (only when the `traefik`
+# Compose profile is active). Per-route rules + TLS hints live as labels on
+# the python-app service in compose.yaml.
+
+# Disable the dashboard by default — re-enable behind auth if you want it.
+api:
+  dashboard: false
+  insecure: false
+
+log:
+  level: INFO
+
+accessLog: {}
+
+# ---- Entrypoints ------------------------------------------------------------
+# :80 redirects everything to :443. :443 terminates TLS.
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+
+# ---- Providers --------------------------------------------------------------
+# Docker socket → Traefik watches container labels and builds routes
+# automatically. exposedByDefault=false means only containers that opt in
+# (via traefik.enable=true) get routes — protects against accidental exposure.
+providers:
+  docker:
+    exposedByDefault: false
+    network: appnet
+    watch: true
+
+# ---- Certificate resolver(s) ------------------------------------------------
+# DEFAULT: HTTP-01 challenge. Works without any DNS provider credentials, but
+# issues one cert per unique subdomain that hits the proxy. For a multi-tenant
+# app this is OK at low scale; Let's Encrypt's rate limits are 50 certs per
+# registered domain per week. The tenant-gate forwardAuth middleware (defined
+# as a label on python-app) blocks REQUESTS for non-tenant subdomains, but
+# can't block the cert REQUEST itself — Traefik would still attempt LE for
+# any subdomain that resolves and hits the proxy.
+#
+# RECOMMENDED FOR PRODUCTION MULTI-TENANT: switch to DNS-01 with a wildcard
+# cert covering *.${BASE_DOMAIN}. One cert covers all current and future
+# tenants. Requires a DNS provider with API support (Cloudflare, Route 53,
+# Hetzner, etc. — see https://doc.traefik.io/traefik/https/acme/#providers).
+#
+# To enable wildcard via DNS-01 (Cloudflare example):
+#   1. Set in .env:  CLOUDFLARE_DNS_API_TOKEN=...
+#   2. Replace the `httpChallenge:` block below with:
+#        dnsChallenge:
+#          provider: cloudflare
+#          resolvers:
+#            - "1.1.1.1:53"
+#            - "8.8.8.8:53"
+#   3. Add to compose.yaml's traefik service env_file or environment:
+#        - CLOUDFLARE_DNS_API_TOKEN=${CLOUDFLARE_DNS_API_TOKEN}
+#   4. Restart traefik. First cert request will create the wildcard.
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "{{ env \"ACME_EMAIL\" }}"
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+      # Uncomment for staging while you're testing — much higher rate limits,
+      # but the certs aren't trusted by browsers.
+      # caServer: https://acme-staging-v02.api.letsencrypt.org/directory

--- a/utilities/system_update.py
+++ b/utilities/system_update.py
@@ -57,10 +57,22 @@ class SystemUpdateManager:
                 config_files = labels.get('com.docker.compose.project.config_files')
 
                 if project_name and working_dir:
+                    # config_files is comma-separated when the user started
+                    # compose with multiple -f flags (e.g. COMPOSE_FILE set
+                    # to compose.yaml:compose.traefik.yaml). We need to
+                    # preserve all of them so the next `up -d` reconstructs
+                    # the same compose merge — otherwise switching to a
+                    # Traefik-style override would silently fall back to the
+                    # default file on the next update.
+                    if config_files:
+                        config_file_list = [f.strip() for f in config_files.split(',') if f.strip()]
+                    else:
+                        config_file_list = ['compose.yaml']
                     self._project_info = {
                         'project_name': project_name,
                         'working_dir': working_dir,
-                        'config_file': config_files.split(',')[0] if config_files else 'compose.yaml',
+                        'config_file': config_file_list[0],          # legacy single-file callers
+                        'config_files': config_file_list,            # full list for the sidecar
                         'container_id': hostname,
                     }
                     return self._project_info
@@ -81,6 +93,7 @@ class SystemUpdateManager:
             'project_name': 'kbm',
             'working_dir': '/opt/kbm',
             'config_file': 'compose.yaml',
+            'config_files': ['compose.yaml'],
             'container_id': os.environ.get('HOSTNAME', 'python-app'),
         }
         return self._project_info
@@ -402,7 +415,10 @@ class SystemUpdateManager:
         project_info = self._get_project_info()
         project_name = project_info['project_name']
         working_dir = project_info['working_dir']
-        config_file = project_info['config_file']
+        # Use the full list of files so multi-file setups (e.g. Traefik
+        # override via COMPOSE_FILE=compose.yaml:compose.traefik.yaml) keep
+        # working through the in-app updater.
+        config_files = project_info.get('config_files') or [project_info['config_file']]
 
         # Sidecar uses our own image, which already has docker + docker compose
         # CLI installed (see Dockerfile). Discover the image tag via inspect on
@@ -416,7 +432,8 @@ class SystemUpdateManager:
 
         # Build the command the sidecar runs. The sleep gives our HTTP response
         # time to flush before the project starts churning.
-        compose_args = f"-f {config_file} -p {project_name} up -d"
+        compose_file_flags = ' '.join(f'-f {f}' for f in config_files)
+        compose_args = f"{compose_file_flags} -p {project_name} up -d"
         if rebuild:
             compose_args += " --build"
 


### PR DESCRIPTION
## Summary

Adds Traefik v3 as a drop-in alternative to Caddy. **Default deployment behavior is unchanged** — Caddy still ships in `compose.yaml` and existing `.env` files keep working with zero migration.

## What ships

| File | Purpose |
|---|---|
| `compose.yaml` | Traefik labels added to `python-app`; Caddy unchanged. Labels are inert when Caddy is the proxy. |
| `compose.traefik.yaml` | Compose override that disables Caddy and adds a `traefik` service. |
| `traefik/traefik.yml` | Traefik v3 static config — entrypoints, Docker provider, Let's Encrypt resolver. |
| `traefik/letsencrypt/` | Bind-mount target for `acme.json`. `.gitignored` for security. |
| `TRAEFIK.md` | Switching steps, cert-challenge trade-offs, DNS-01 wildcard recipe. |
| `app_multitenant.py` | `/_internal/check-domain` now reads from `?domain=` OR `X-Forwarded-Host` OR `Host`. |
| `utilities/system_update.py` | Fix updater to honor multi-file `COMPOSE_FILE` so the override survives in-app updates. |
| `.env.production.template` | New optional `COMPOSE_FILE` line (commented out, default Caddy). |
| `deploy/install_vps.sh` | Creates `traefik/letsencrypt/` on fresh installs. |

## Switching from Caddy to Traefik

On the VPS:

```bash
# 1. Pull this release
# 2. Edit .env, uncomment:
COMPOSE_FILE=compose.yaml:compose.traefik.yaml

# 3. Restart
docker compose -p kbm down
docker compose -p kbm up -d
```

Reverse the env change to switch back.

## Routing labels (what Traefik picks up)

```
kbm-root router    → Host(BASE_DOMAIN) || Host(www.BASE_DOMAIN)
kbm-tenants router → HostRegexp(^[a-z0-9-]+\.BASE_DOMAIN$)
                     middleware: tenant-gate@docker (forwardauth → /_internal/check-domain)
kbm-app service    → port 8000
```

The `tenant-gate` middleware calls the same endpoint Caddy uses for `on_demand_tls.ask`. The endpoint now accepts the candidate host from three sources (Caddy query param, Traefik forwardauth header, request Host) so both proxies share one code path.

## Cert challenge

`traefik/traefik.yml` defaults to **HTTP-01** (no DNS provider creds needed). For production multi-tenant deployments, `TRAEFIK.md` documents how to switch to **DNS-01 wildcard** (`*.${BASE_DOMAIN}`) — one cert covers all tenants, no rate-limit risk, recipe for Cloudflare.

## Updater fix (folded in)

`system_update.py` previously took only the first entry from the `com.docker.compose.project.config_files` label. That meant once a user set `COMPOSE_FILE=compose.yaml:compose.traefik.yaml`, the next in-app update would silently drop the override and bring Caddy back. Now the updater preserves the full file list across iterations.

## Backward compatibility

- Existing `.env` files without `COMPOSE_FILE` continue using `compose.yaml` only → Caddy keeps running exactly as before.
- The new Traefik labels on `python-app` have no effect when Caddy is the proxy.
- No `.env` migration needed for current deploys.

## Test plan

- [ ] **Caddy unchanged path:** pull this branch, redeploy without touching .env. Confirm Caddy still serves the root domain and tenant subdomains as before.
- [ ] **Switch to Traefik:** set `COMPOSE_FILE` in .env, `down` + `up -d`. Confirm:
  - root domain serves with a fresh LE cert (HTTP-01)
  - tenant subdomains serve with their own per-subdomain certs
  - a request to a non-tenant subdomain (e.g. `randomstring.BASE_DOMAIN`) returns 401 via the forwardauth middleware
- [ ] **In-app updater with Traefik:** trigger Update Now from the admin panel. Confirm Traefik is still the proxy after the restart (i.e., the multi-file fix worked).
- [ ] **Switch back to Caddy:** comment out `COMPOSE_FILE`, `down` + `up -d`. Caddy returns.
- [ ] **DNS-01 wildcard (optional):** follow the TRAEFIK.md recipe with Cloudflare creds, confirm a single wildcard cert is issued and tenant subdomains use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)