### PR TITLE
Fix Traefik tenant TLS: use DNS-01 wildcard (Namecheap)

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -37,16 +37,25 @@ DOCKER_GID=999
 # Default: compose.yaml — Caddy with on-demand TLS via ask endpoint.
 # Alternative: append compose.traefik.yaml to switch to Traefik. Compose
 # merges both files, disables caddy via an unused profile, and adds traefik.
-# See TRAEFIK.md for trade-offs and the DNS-01 wildcard option.
+# See TRAEFIK.md for trade-offs.
 #
 # To use Traefik instead, uncomment the line below:
 # COMPOSE_FILE=compose.yaml:compose.traefik.yaml
 
-# --- Optional: Traefik DNS-01 wildcard support ---
-# Only used when COMPOSE_FILE includes compose.traefik.yaml AND you've
-# edited traefik/traefik.yml to enable the dnsChallenge block. See TRAEFIK.md.
-# Example: Cloudflare API token with Zone:DNS:Edit on the BASE_DOMAIN zone.
-# CLOUDFLARE_DNS_API_TOKEN=
+# --- REQUIRED when using Traefik: DNS-01 wildcard credentials ---
+# Traefik (unlike Caddy) has no on-demand TLS, so multi-tenant subdomains are
+# served by ONE wildcard cert (*.${BASE_DOMAIN}) issued via the Let's Encrypt
+# DNS-01 challenge. traefik/traefik.yml is configured for Namecheap.
+#
+# Namecheap one-time setup:
+#   - Enable API access:  Namecheap → Profile → Tools → Namecheap API Access
+#   - Whitelist the VPS PUBLIC IP in that same API settings page
+#   - The BASE_DOMAIN zone must use Namecheap BasicDNS (default nameservers)
+# Then fill these in (leave blank if you're using Caddy):
+NAMECHEAP_API_USER=
+NAMECHEAP_API_KEY=
+# Optional — raise if Namecheap DNS propagation is slow (seconds). Default 1800.
+# NAMECHEAP_PROPAGATION_TIMEOUT=1800
 
 # --- App settings ---
 # Multi-tenant mode does not use a single DATABASE_URI. Each tenant has its own

--- a/TRAEFIK.md
+++ b/TRAEFIK.md
@@ -47,53 +47,63 @@ On your VPS:
 To switch back to Caddy: comment out `COMPOSE_FILE`, then `down` + `up -d`
 again.
 
-## Cert challenge: HTTP-01 vs DNS-01 wildcard
+## Cert challenge: DNS-01 wildcard (required for multi-tenant)
 
-Out of the box `traefik/traefik.yml` is configured for the **HTTP-01**
-challenge. This works without any DNS provider creds, but Traefik issues
-**one cert per unique subdomain** that hits the proxy. Let's Encrypt's
-hard limit is 50 certs per registered domain per week.
+`traefik/traefik.yml` is configured for the **DNS-01** challenge and issues
+a single **wildcard cert** covering `*.${BASE_DOMAIN}`. This is required,
+not optional, for this app:
 
-The `tenant-gate` forwardauth middleware (defined as a label on
-`python-app` in `compose.yaml`) gates per-request authorization — returns
-401 for subdomains that don't map to active tenants. **It doesn't gate
-cert issuance** — Traefik will still attempt LE for any subdomain that
-resolves to your VPS and hits port 443. An attacker controlling a
-wildcard DNS record pointed at your IP could exhaust your rate limit.
+- Tenants live on arbitrary, dynamically created subdomains
+  (`<tenant>.${BASE_DOMAIN}`), matched by the `kbm-tenants` `HostRegexp`
+  router.
+- **Traefik has no on-demand TLS** (Caddy's killer multi-tenant feature).
+  It must know cert domains up front and *cannot derive a hostname from a
+  regex*. So the tenant router requests a wildcard.
+- **Let's Encrypt only issues wildcards over DNS-01** — HTTP-01 cannot.
+  (The original Traefik labels asked for a wildcard while the resolver was
+  still on HTTP-01; that mismatch meant the ACME order failed and every
+  tenant subdomain got Traefik's self-signed default cert — the "Not
+  secure" bug. DNS-01 is the fix.)
 
-For a public multi-tenant production deployment, **switch to DNS-01 with
-a wildcard cert** covering `*.${BASE_DOMAIN}`. One cert covers all
-current and future tenants. No per-subdomain issuance, no rate-limit risk.
+One wildcard cert covers all current and future tenants — no per-subdomain
+issuance, no Let's Encrypt rate-limit risk.
 
-### Enabling DNS-01 wildcard (Cloudflare example)
+The `tenant-gate` forwardauth middleware still gates each *request* (401/404
+for subdomains that don't map to an active tenant); the wildcard cert covers
+TLS, the middleware covers authorization.
 
-1. Move your DNS to Cloudflare (or any provider supported by lego/Traefik).
-   Create an API token with `Zone:DNS:Edit` on the `BASE_DOMAIN` zone.
-2. Add to `.env`:
-   ```
-   CLOUDFLARE_DNS_API_TOKEN=<your token>
-   ```
-3. Edit `traefik/traefik.yml`. Replace the `httpChallenge:` block under
-   `certificatesResolvers.letsencrypt.acme` with:
-   ```yaml
-   dnsChallenge:
-     provider: cloudflare
-     resolvers:
-       - "1.1.1.1:53"
-       - "8.8.8.8:53"
-   ```
-4. Edit `compose.traefik.yaml`, add an `environment:` block to the
-   `traefik` service:
-   ```yaml
-   environment:
-     - CLOUDFLARE_DNS_API_TOKEN=${CLOUDFLARE_DNS_API_TOKEN}
-   ```
-5. `docker compose -p kbm restart traefik`. Watch the logs — Traefik will
-   request a wildcard cert via DNS-01 challenge.
+### DNS-01 is configured for Namecheap
 
-For other providers (Route 53, Hetzner, DigitalOcean, etc.), see
-<https://doc.traefik.io/traefik/https/acme/#providers>. Each provider
-needs slightly different env vars.
+`buywithvesta.com` uses **Namecheap** DNS, so the resolver uses the lego
+`namecheap` provider. One-time setup in the Namecheap dashboard:
+
+1. **Enable API access**: Profile → Tools → Namecheap API Access.
+2. **Whitelist the VPS public IP** in that same API settings page —
+   Namecheap rejects API calls from non-whitelisted IPs, which would make
+   every cert request fail.
+3. The `BASE_DOMAIN` zone must use **Namecheap BasicDNS** (their default
+   nameservers) so the API can write the `_acme-challenge` TXT record.
+
+Then add to `.env`:
+```
+NAMECHEAP_API_USER=<your Namecheap username>
+NAMECHEAP_API_KEY=<API key from the API Access page>
+# Optional, raise if propagation is slow (seconds):
+# NAMECHEAP_PROPAGATION_TIMEOUT=1800
+```
+
+`compose.traefik.yaml` already passes these to the `traefik` container, and
+`traefik/traefik.yml` already selects `provider: namecheap`. Just fill in
+`.env` and `docker compose -p kbm up -d`. Watch `docker logs traefik -f` —
+you should see a DNS-01 challenge and a wildcard cert get issued.
+
+### Using a different DNS provider
+
+If you ever move DNS off Namecheap, change `provider:` in
+`traefik/traefik.yml`, swap the credential vars in `.env` +
+`compose.traefik.yaml`, and consult
+<https://doc.traefik.io/traefik/https/acme/#providers> for that provider's
+required env vars.
 
 ## How the routing labels work
 

--- a/compose.traefik.yaml
+++ b/compose.traefik.yaml
@@ -23,8 +23,19 @@ services:
     container_name: traefik
     restart: unless-stopped
     init: true
+    # env_file injects every var from .env into the container, so lego's DNS-01
+    # (Namecheap) provider picks these up automatically. The explicit
+    # environment entries below document the dependency and surface an empty
+    # value if a credential is missing, instead of silently falling back to a
+    # self-signed cert. Switch these var names if you use a different provider.
     env_file:
       - .env
+    environment:
+      - NAMECHEAP_API_USER=${NAMECHEAP_API_USER:-}
+      - NAMECHEAP_API_KEY=${NAMECHEAP_API_KEY:-}
+      # Namecheap propagation can lag; give lego longer before it asks LE to
+      # verify. Optional — defaults are used if unset.
+      - NAMECHEAP_PROPAGATION_TIMEOUT=${NAMECHEAP_PROPAGATION_TIMEOUT:-1800}
     ports:
       - "80:80"
       - "443:443"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -38,37 +38,50 @@ providers:
     watch: true
 
 # ---- Certificate resolver(s) ------------------------------------------------
-# DEFAULT: HTTP-01 challenge. Works without any DNS provider credentials, but
-# issues one cert per unique subdomain that hits the proxy. For a multi-tenant
-# app this is OK at low scale; Let's Encrypt's rate limits are 50 certs per
-# registered domain per week. The tenant-gate forwardAuth middleware (defined
-# as a label on python-app) blocks REQUESTS for non-tenant subdomains, but
-# can't block the cert REQUEST itself — Traefik would still attempt LE for
-# any subdomain that resolves and hits the proxy.
+# DNS-01 challenge with a WILDCARD cert covering *.${BASE_DOMAIN}.
 #
-# RECOMMENDED FOR PRODUCTION MULTI-TENANT: switch to DNS-01 with a wildcard
-# cert covering *.${BASE_DOMAIN}. One cert covers all current and future
-# tenants. Requires a DNS provider with API support (Cloudflare, Route 53,
-# Hetzner, etc. — see https://doc.traefik.io/traefik/https/acme/#providers).
+# Why DNS-01 (and not HTTP-01)?
+#   This is a multi-tenant app: tenants live on arbitrary, dynamically created
+#   subdomains (<tenant>.${BASE_DOMAIN}), matched by a HostRegexp router in
+#   compose.yaml. Traefik — unlike Caddy — has no on-demand TLS: it must know
+#   the cert domains up front and cannot derive a concrete hostname from a
+#   regex. The tenant router therefore requests a WILDCARD (*.${BASE_DOMAIN}),
+#   and Let's Encrypt only issues wildcards over DNS-01. (HTTP-01 cannot issue
+#   wildcards — that mismatch was the bug: tenant subdomains got Traefik's
+#   self-signed default cert and showed "Not secure".)
 #
-# To enable wildcard via DNS-01 (Cloudflare example):
-#   1. Set in .env:  CLOUDFLARE_DNS_API_TOKEN=...
-#   2. Replace the `httpChallenge:` block below with:
-#        dnsChallenge:
-#          provider: cloudflare
-#          resolvers:
-#            - "1.1.1.1:53"
-#            - "8.8.8.8:53"
-#   3. Add to compose.yaml's traefik service env_file or environment:
-#        - CLOUDFLARE_DNS_API_TOKEN=${CLOUDFLARE_DNS_API_TOKEN}
-#   4. Restart traefik. First cert request will create the wildcard.
+# One wildcard cert covers all current and future tenants — no per-subdomain
+# issuance, no Let's Encrypt rate-limit risk.
+#
+# REQUIRED: DNS provider API credentials in .env. Configured here for Namecheap
+# (lego provider `namecheap`), which needs:
+#     NAMECHEAP_API_USER   — your Namecheap account username
+#     NAMECHEAP_API_KEY    — API key from Namecheap → Profile → Tools → API Access
+# The traefik service in compose.traefik.yaml loads .env, so lego picks these
+# up automatically. For a different provider change `provider:` below and set
+# that provider's vars — see https://doc.traefik.io/traefik/https/acme/#providers
+#
+# NAMECHEAP PREREQUISITES (one-time, in the Namecheap dashboard):
+#   1. Enable API Access (Profile → Tools → Namecheap API Access).
+#   2. Whitelist the VPS's PUBLIC IP under the API access settings — Namecheap
+#      rejects API calls from non-whitelisted IPs, which would make every cert
+#      request fail.
+#   3. The ${BASE_DOMAIN} zone must use Namecheap BasicDNS (their default
+#      nameservers) so the API can write the _acme-challenge TXT record.
 certificatesResolvers:
   letsencrypt:
     acme:
       email: "{{ env \"ACME_EMAIL\" }}"
       storage: /letsencrypt/acme.json
-      httpChallenge:
-        entryPoint: web
+      dnsChallenge:
+        provider: namecheap
+        # Public resolvers used to verify the _acme-challenge TXT record has
+        # propagated before telling Let's Encrypt to check it. Namecheap DNS
+        # can be slow to propagate, so we also bump the propagation timeout
+        # via NAMECHEAP_PROPAGATION_TIMEOUT in .env (see compose.traefik.yaml).
+        resolvers:
+          - "1.1.1.1:53"
+          - "8.8.8.8:53"
       # Uncomment for staging while you're testing — much higher rate limits,
       # but the certs aren't trusted by browsers.
       # caServer: https://acme-staging-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
## Problem

After switching the reverse proxy from Caddy to Traefik, tenant subdomains
(`<tenant>.buywithvesta.com`) show **"Not secure"** in the browser and fall back
to the root / app-admin view instead of loading the tenant app.

## Root cause

The `kbm-tenants` router in `compose.yaml` requests a **wildcard certificate**:

```yaml
- "traefik.http.routers.kbm-tenants.tls.domains[0].main=${BASE_DOMAIN}"
- "traefik.http.routers.kbm-tenants.tls.domains[0].sans=*.${BASE_DOMAIN}"
```

…but `traefik/traefik.yml` was still configured for the **HTTP-01** challenge.
**Let's Encrypt only issues wildcard certs over DNS-01** — HTTP-01 cannot. So the
ACME order for `*.buywithvesta.com` fails and Traefik serves its built-in
**self-signed default cert** for every tenant subdomain → the "Not secure" banner.
The only host with a valid, trusted cert is the apex (`buywithvesta.com`, the
app-admin page), which is why tenant subdomains appear to fall back there.

Unlike Caddy, **Traefik has no on-demand TLS** and cannot derive a concrete
hostname from the `HostRegexp` tenant router, so a **DNS-01 wildcard** is the
correct approach for dynamic multi-tenant subdomains. The config was effectively
half-migrated (wildcard request + HTTP-01 resolver).

## Fix

Switch the cert resolver to **DNS-01** using the **Namecheap** provider
(`buywithvesta.com` DNS is on Namecheap):

- **`traefik/traefik.yml`** — replace `httpChallenge` with `dnsChallenge`
  (`provider: namecheap`, public resolvers for propagation checks).
- **`compose.traefik.yaml`** — pass `NAMECHEAP_API_USER` / `NAMECHEAP_API_KEY`
  (and an optional `NAMECHEAP_PROPAGATION_TIMEOUT`) through to the traefik container.
- **`.env.production.template`** — document the now-required Namecheap DNS-01
  credentials and one-time API setup.
- **`TRAEFIK.md`** — rewrite the cert-challenge section for the DNS-01/Namecheap
  default and explain why HTTP-01 cannot work here.

## Operator action required before this takes effect

1. In Namecheap: **enable API access**, **whitelist the VPS public IP**, and
   ensure the zone uses **Namecheap BasicDNS**.
2. Set `NAMECHEAP_API_USER` and `NAMECHEAP_API_KEY` in `.env` on the VPS.
3. `docker compose -p kbm up -d`, then watch `docker logs traefik -f` for the
   DNS-01 challenge and a wildcard `*.buywithvesta.com` cert to issue.

## Notes

- No code/runtime changes — this is reverse-proxy/TLS config only.
- If DNS ever moves off Namecheap, change `provider:` in `traefik/traefik.yml`
  and swap the credential vars.

https://claude.ai/code/session_01NZYjtveKyr5xGR9rkDdCNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZYjtveKyr5xGR9rkDdCNQ)_