### PR TITLE
Traefik TLS: switch DNS-01 wildcard from Namecheap to Cloudflare

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -45,17 +45,18 @@ DOCKER_GID=999
 # --- REQUIRED when using Traefik: DNS-01 wildcard credentials ---
 # Traefik (unlike Caddy) has no on-demand TLS, so multi-tenant subdomains are
 # served by ONE wildcard cert (*.${BASE_DOMAIN}) issued via the Let's Encrypt
-# DNS-01 challenge. traefik/traefik.yml is configured for Namecheap.
+# DNS-01 challenge. traefik/traefik.yml is configured for Cloudflare (free, and
+# zero-maintenance — no source-IP whitelisting like Namecheap required).
 #
-# Namecheap one-time setup:
-#   - Enable API access:  Namecheap → Profile → Tools → Namecheap API Access
-#   - Whitelist the VPS PUBLIC IP in that same API settings page
-#   - The BASE_DOMAIN zone must use Namecheap BasicDNS (default nameservers)
-# Then fill these in (leave blank if you're using Caddy):
-NAMECHEAP_API_USER=
-NAMECHEAP_API_KEY=
-# Optional — raise if Namecheap DNS propagation is slow (seconds). Default 1800.
-# NAMECHEAP_PROPAGATION_TIMEOUT=1800
+# Cloudflare one-time setup:
+#   - Add ${BASE_DOMAIN} to a free Cloudflare account, then point the domain's
+#     nameservers at Cloudflare (Namecheap dashboard → Domain List → Manage →
+#     Nameservers → Custom DNS). This is a UI change, NOT the Namecheap API.
+#   - Create a scoped token: Cloudflare → My Profile → API Tokens → Create Token
+#     → "Edit zone DNS" template, scoped to the ${BASE_DOMAIN} zone
+#     (Zone:DNS:Edit + Zone:Zone:Read).
+# Then fill this in (leave blank if you're using Caddy):
+CF_DNS_API_TOKEN=
 
 # --- App settings ---
 # Multi-tenant mode does not use a single DATABASE_URI. Each tenant has its own

--- a/TRAEFIK.md
+++ b/TRAEFIK.md
@@ -72,34 +72,41 @@ The `tenant-gate` forwardauth middleware still gates each *request* (401/404
 for subdomains that don't map to an active tenant); the wildcard cert covers
 TLS, the middleware covers authorization.
 
-### DNS-01 is configured for Namecheap
+### DNS-01 is configured for Cloudflare
 
-`buywithvesta.com` uses **Namecheap** DNS, so the resolver uses the lego
-`namecheap` provider. One-time setup in the Namecheap dashboard:
+The resolver uses the lego `cloudflare` provider. Cloudflare DNS is **free**
+and, unlike Namecheap, requires **no source-IP whitelisting** — so renewals
+keep working even if the VPS IP changes, and propagation takes seconds instead
+of up to half an hour. Setup is one-time and then completely hands-off.
 
-1. **Enable API access**: Profile → Tools → Namecheap API Access.
-2. **Whitelist the VPS public IP** in that same API settings page —
-   Namecheap rejects API calls from non-whitelisted IPs, which would make
-   every cert request fail.
-3. The `BASE_DOMAIN` zone must use **Namecheap BasicDNS** (their default
-   nameservers) so the API can write the `_acme-challenge` TXT record.
+One-time setup:
+
+1. **Add the zone to Cloudflare**: create a free Cloudflare account and add
+   `buywithvesta.com` as a site. Cloudflare imports your existing records.
+2. **Point nameservers at Cloudflare**: in the **Namecheap** dashboard →
+   Domain List → Manage → Nameservers → switch from BasicDNS to **Custom DNS**
+   and enter the two nameservers Cloudflare gives you. This is a UI change —
+   **not** the Namecheap API. Wait for Cloudflare to show the zone as *Active*
+   (usually minutes).
+3. **Create a scoped API token**: Cloudflare → My Profile → API Tokens →
+   Create Token → **"Edit zone DNS"** template → scope it to the
+   `buywithvesta.com` zone. The token gets `Zone:DNS:Edit` + `Zone:Zone:Read`,
+   which is exactly what lego needs to write the `_acme-challenge` TXT record.
 
 Then add to `.env`:
 ```
-NAMECHEAP_API_USER=<your Namecheap username>
-NAMECHEAP_API_KEY=<API key from the API Access page>
-# Optional, raise if propagation is slow (seconds):
-# NAMECHEAP_PROPAGATION_TIMEOUT=1800
+CF_DNS_API_TOKEN=<the scoped token from step 3>
 ```
 
-`compose.traefik.yaml` already passes these to the `traefik` container, and
-`traefik/traefik.yml` already selects `provider: namecheap`. Just fill in
+`compose.traefik.yaml` already passes this to the `traefik` container, and
+`traefik/traefik.yml` already selects `provider: cloudflare`. Just fill in
 `.env` and `docker compose -p kbm up -d`. Watch `docker logs traefik -f` —
-you should see a DNS-01 challenge and a wildcard cert get issued.
+you should see a DNS-01 challenge and a wildcard cert get issued (typically
+within a minute, since Cloudflare propagation is near-instant).
 
 ### Using a different DNS provider
 
-If you ever move DNS off Namecheap, change `provider:` in
+If you ever move DNS off Cloudflare, change `provider:` in
 `traefik/traefik.yml`, swap the credential vars in `.env` +
 `compose.traefik.yaml`, and consult
 <https://doc.traefik.io/traefik/https/acme/#providers> for that provider's

--- a/compose.traefik.yaml
+++ b/compose.traefik.yaml
@@ -24,18 +24,14 @@ services:
     restart: unless-stopped
     init: true
     # env_file injects every var from .env into the container, so lego's DNS-01
-    # (Namecheap) provider picks these up automatically. The explicit
-    # environment entries below document the dependency and surface an empty
-    # value if a credential is missing, instead of silently falling back to a
-    # self-signed cert. Switch these var names if you use a different provider.
+    # (Cloudflare) provider picks up CF_DNS_API_TOKEN automatically. The explicit
+    # environment entry below documents the dependency and surfaces an empty
+    # value if the credential is missing, instead of silently falling back to a
+    # self-signed cert. Switch this var name if you use a different provider.
     env_file:
       - .env
     environment:
-      - NAMECHEAP_API_USER=${NAMECHEAP_API_USER:-}
-      - NAMECHEAP_API_KEY=${NAMECHEAP_API_KEY:-}
-      # Namecheap propagation can lag; give lego longer before it asks LE to
-      # verify. Optional — defaults are used if unset.
-      - NAMECHEAP_PROPAGATION_TIMEOUT=${NAMECHEAP_PROPAGATION_TIMEOUT:-1800}
+      - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN:-}
     ports:
       - "80:80"
       - "443:443"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -53,32 +53,39 @@ providers:
 # One wildcard cert covers all current and future tenants — no per-subdomain
 # issuance, no Let's Encrypt rate-limit risk.
 #
-# REQUIRED: DNS provider API credentials in .env. Configured here for Namecheap
-# (lego provider `namecheap`), which needs:
-#     NAMECHEAP_API_USER   — your Namecheap account username
-#     NAMECHEAP_API_KEY    — API key from Namecheap → Profile → Tools → API Access
-# The traefik service in compose.traefik.yaml loads .env, so lego picks these
-# up automatically. For a different provider change `provider:` below and set
-# that provider's vars — see https://doc.traefik.io/traefik/https/acme/#providers
+# REQUIRED: DNS provider API credentials in .env. Configured here for Cloudflare
+# (lego provider `cloudflare`), which needs just ONE scoped API token:
+#     CF_DNS_API_TOKEN   — a Cloudflare API token (see prerequisites below)
+# The traefik service in compose.traefik.yaml loads .env, so lego picks this up
+# automatically. For a different provider change `provider:` below and set that
+# provider's vars — see https://doc.traefik.io/traefik/https/acme/#providers
 #
-# NAMECHEAP PREREQUISITES (one-time, in the Namecheap dashboard):
-#   1. Enable API Access (Profile → Tools → Namecheap API Access).
-#   2. Whitelist the VPS's PUBLIC IP under the API access settings — Namecheap
-#      rejects API calls from non-whitelisted IPs, which would make every cert
-#      request fail.
-#   3. The ${BASE_DOMAIN} zone must use Namecheap BasicDNS (their default
-#      nameservers) so the API can write the _acme-challenge TXT record.
+# WHY CLOUDFLARE (and not Namecheap): Cloudflare DNS is free, propagates in
+# seconds (no slow-propagation timeout hacks), and — unlike Namecheap — needs
+# NO source-IP whitelisting, so cert renewals keep working even if the VPS IP
+# changes. Setup is one-time and then completely hands-off.
+#
+# CLOUDFLARE PREREQUISITES (one-time):
+#   1. Add the ${BASE_DOMAIN} zone to a (free) Cloudflare account and switch the
+#      domain's nameservers to the two Cloudflare gives you. This is a UI change
+#      in the Namecheap dashboard (Domain List → Manage → Nameservers → Custom
+#      DNS) — NOT the Namecheap API.
+#   2. Create a scoped API token: Cloudflare dashboard → My Profile → API Tokens
+#      → Create Token → "Edit zone DNS" template. Scope it to the ${BASE_DOMAIN}
+#      zone. The token must have Zone:DNS:Edit + Zone:Zone:Read so lego can
+#      write the _acme-challenge TXT record.
+#   3. Put that token in .env as CF_DNS_API_TOKEN (see compose.traefik.yaml).
 certificatesResolvers:
   letsencrypt:
     acme:
       email: "{{ env \"ACME_EMAIL\" }}"
       storage: /letsencrypt/acme.json
       dnsChallenge:
-        provider: namecheap
+        provider: cloudflare
         # Public resolvers used to verify the _acme-challenge TXT record has
-        # propagated before telling Let's Encrypt to check it. Namecheap DNS
-        # can be slow to propagate, so we also bump the propagation timeout
-        # via NAMECHEAP_PROPAGATION_TIMEOUT in .env (see compose.traefik.yaml).
+        # propagated before telling Let's Encrypt to check it. Cloudflare
+        # propagates in seconds, so lego's default propagation timeout is fine
+        # — no override needed.
         resolvers:
           - "1.1.1.1:53"
           - "8.8.8.8:53"


### PR DESCRIPTION
## Why

The tenant-subdomain "Not secure" pain came entirely from the **Traefik → wildcard cert → DNS-01 → Namecheap API** chain. Namecheap's DNS-01 requires enabling its API **and** whitelisting the VPS public IP — which silently breaks cert renewals whenever the IP changes, and propagates slowly (hence the 30-min timeout hack).

We're keeping **Traefik** as the proxy (other apps on the VPS use it, so Caddy would only fight it for ports 80/443), but swapping the DNS-01 provider to **Cloudflare**: free, no source-IP whitelisting, near-instant propagation — a genuinely zero-maintenance path to the `*.${BASE_DOMAIN}` wildcard cert.

No Traefik image bump needed — this works with the pinned `traefik:v3.1`. (Hostinger's own DNS provider was considered but needs lego 4.27 / Traefik ≥ v3.5.4 and is far less battle-tested, so Cloudflare won.)

## Changes

| File | Change |
|---|---|
| `traefik/traefik.yml` | `provider: namecheap` → `cloudflare`; rewrote prerequisite comments; dropped the slow-propagation note |
| `compose.traefik.yaml` | `NAMECHEAP_API_USER` / `NAMECHEAP_API_KEY` / `NAMECHEAP_PROPAGATION_TIMEOUT` → single `CF_DNS_API_TOKEN` |
| `.env.production.template` | Cloudflare token field + one-time nameserver setup steps |
| `TRAEFIK.md` | Rewrote the DNS-01 section for Cloudflare |

## One-time setup (no Namecheap API)

1. Add `buywithvesta.com` to a free Cloudflare account (it imports existing records).
2. Point nameservers at Cloudflare — Namecheap dashboard → Domain List → Manage → Nameservers → **Custom DNS** (UI only, not the API). Wait for the zone to show **Active**.
3. Create a scoped token: Cloudflare → My Profile → API Tokens → **"Edit zone DNS"** template, scoped to the zone (`Zone:DNS:Edit` + `Zone:Zone:Read`).
4. On the VPS: set `CF_DNS_API_TOKEN=<token>` in `.env`, then `docker compose -p kbm up -d`. Watch `docker logs traefik -f` for the DNS-01 challenge + wildcard issuance.

⚠️ After the nameserver switch, verify the A records (`buywithvesta.com` and `*.buywithvesta.com` → VPS IP) exist in Cloudflare, kept **DNS-only / grey-cloud** for the Traefik + Let's Encrypt setup.

https://claude.ai/code/session_01QyrWWjRkKWzjh6kj3SdmZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyrWWjRkKWzjh6kj3SdmZg)_