### PR TITLE
Add compose.external-traefik.yaml for shared/central Traefik deploys

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -39,8 +39,16 @@ DOCKER_GID=999
 # merges both files, disables caddy via an unused profile, and adds traefik.
 # See TRAEFIK.md for trade-offs.
 #
-# To use Traefik instead, uncomment the line below:
+# To run KBM's OWN bundled Traefik instead of Caddy, uncomment:
 # COMPOSE_FILE=compose.yaml:compose.traefik.yaml
+#
+# To run KBM behind an EXISTING external Traefik already on the host (a shared
+# proxy that already owns ports 80/443 and fronts other apps), uncomment this
+# instead. It disables Caddy, publishes the app on 127.0.0.1:8000 for the
+# external proxy's forwardauth, and emits routing labels using the `cfdns`
+# resolver. The external Traefik must define a Cloudflare DNS-01 resolver named
+# `cfdns`. See TRAEFIK.md ("Running behind an existing external Traefik").
+# COMPOSE_FILE=compose.yaml:compose.external-traefik.yaml
 
 # --- REQUIRED when using Traefik: DNS-01 wildcard credentials ---
 # Traefik (unlike Caddy) has no on-demand TLS, so multi-tenant subdomains are

--- a/TRAEFIK.md
+++ b/TRAEFIK.md
@@ -112,6 +112,56 @@ If you ever move DNS off Cloudflare, change `provider:` in
 <https://doc.traefik.io/traefik/https/acme/#providers> for that provider's
 required env vars.
 
+## Running behind an existing external Traefik
+
+`compose.traefik.yaml` (above) starts KBM's **own** Traefik. That only works if
+nothing else on the host already holds ports 80/443. If you run a **shared,
+central Traefik** for several apps (a common VPS pattern — e.g. Hostinger's
+one-click Traefik in `network_mode: host`), KBM can't start a second proxy on
+the same ports. Use **`compose.external-traefik.yaml`** instead:
+
+```
+COMPOSE_FILE=compose.yaml:compose.external-traefik.yaml
+```
+
+This override:
+
+- Disables the bundled Caddy (`profiles: ["disabled"]`).
+- Publishes the app on `127.0.0.1:8000`. A host-network Traefik can't resolve
+  the `python-app` container name over docker DNS, so the `tenant-gate`
+  forwardauth must reach the app via the host loopback. Inbound app traffic is
+  still routed by the external Traefik to the container IP via the docker
+  provider.
+- Emits the full router set — `kbm-root` (apex), `kbm-www` (308→apex redirect),
+  `kbm-tenants` (wildcard, forwardauth-gated) — all using a cert resolver named
+  **`cfdns`**, with explicit priorities so apex/www are never gated as tenants.
+
+### What the external Traefik must provide
+
+Add a Cloudflare DNS-01 resolver named `cfdns` to your central Traefik,
+**alongside** whatever resolver your other apps already use (don't replace it):
+
+```
+--certificatesresolvers.cfdns.acme.dnschallenge=true
+--certificatesresolvers.cfdns.acme.dnschallenge.provider=cloudflare
+--certificatesresolvers.cfdns.acme.email=${ACME_EMAIL}
+--certificatesresolvers.cfdns.acme.storage=/letsencrypt/acme.json
+```
+
+and pass `CF_DNS_API_TOKEN` (a scoped Cloudflare "Edit zone DNS" token for
+`${BASE_DOMAIN}`) into the **Traefik** container's environment. The token lives
+with Traefik, not with KBM. DNS records for `@`, `www`, and `*.${BASE_DOMAIN}`
+must be **DNS-only (grey cloud)** A records pointing at the host so Traefik
+terminates TLS directly.
+
+### Survives in-app updates
+
+The in-app updater records the active `config_files` from the running
+container's compose labels and reconstructs the same merge on every `up -d`, and
+the base `compose.yaml` stays pristine (so the auto-stash/`reset --hard` reverts
+nothing). Once `COMPOSE_FILE` is set in `.env` (which is gitignored), the
+override sticks across updates.
+
 ## How the routing labels work
 
 Every router rule lives as a label on the `python-app` service in

--- a/compose.external-traefik.yaml
+++ b/compose.external-traefik.yaml
@@ -1,0 +1,78 @@
+# Compose override for running KBM behind an EXISTING, EXTERNAL Traefik that is
+# already on the host (e.g. a shared/central Traefik that owns ports 80/443 and
+# fronts other apps too). This is different from compose.traefik.yaml, which
+# starts KBM's OWN Traefik — you can't do that when another proxy already holds
+# 80/443.
+#
+# Enable by setting COMPOSE_FILE in .env:
+#
+#     COMPOSE_FILE=compose.yaml:compose.external-traefik.yaml
+#
+# What it does, relative to the base compose.yaml:
+#   - Disables the bundled Caddy (it would fail to bind 80/443).
+#   - Publishes the app on 127.0.0.1:8000 so a HOST-NETWORK external Traefik can
+#     reach the tenant-gate forwardauth endpoint (it can't resolve `python-app`
+#     by docker DNS because it isn't on the app's docker network).
+#   - Restates the full Traefik label set so the external Traefik routes:
+#       * apex  -> app           (router kbm-root,    priority 100)
+#       * www   -> 308 to apex    (router kbm-www,     priority 100)
+#       * *.tenant subdomains    (router kbm-tenants, priority 1, forwardauth-gated)
+#     all using the `cfdns` cert resolver (Cloudflare DNS-01 wildcard). The
+#     external Traefik must define a resolver named `cfdns`; see TRAEFIK.md.
+#
+# The in-app updater records the active config_files on the container and
+# reconstructs this same merge on every `up -d`, so updates never silently
+# fall back to Caddy.
+
+services:
+  caddy:
+    profiles: ["disabled"]
+
+  python-app:
+    # Loopback publish for the host-network external Traefik's forwardauth call.
+    ports:
+      - "127.0.0.1:8000:8000"
+    labels:
+      - "traefik.enable=true"
+      # Explicit, project-prefixed network name so the external Traefik picks
+      # the right container IP without guessing.
+      - "traefik.docker.network=kbm_appnet"
+      - "traefik.http.services.kbm-app.loadbalancer.server.port=8000"
+
+      # Router: apex (main site). Priority above kbm-tenants so the apex is
+      # never gated as a tenant.
+      - "traefik.http.routers.kbm-root.rule=Host(`${BASE_DOMAIN}`)"
+      - "traefik.http.routers.kbm-root.priority=100"
+      - "traefik.http.routers.kbm-root.entrypoints=websecure"
+      - "traefik.http.routers.kbm-root.tls=true"
+      - "traefik.http.routers.kbm-root.tls.certresolver=cfdns"
+      - "traefik.http.routers.kbm-root.tls.domains[0].main=${BASE_DOMAIN}"
+      - "traefik.http.routers.kbm-root.tls.domains[0].sans=*.${BASE_DOMAIN}"
+      - "traefik.http.routers.kbm-root.service=kbm-app"
+
+      # Router: www -> apex 308 redirect (the app treats any subdomain, incl.
+      # "www", as a tenant, so it must be redirected rather than routed).
+      - "traefik.http.routers.kbm-www.rule=Host(`www.${BASE_DOMAIN}`)"
+      - "traefik.http.routers.kbm-www.priority=100"
+      - "traefik.http.routers.kbm-www.entrypoints=websecure"
+      - "traefik.http.routers.kbm-www.tls=true"
+      - "traefik.http.routers.kbm-www.tls.certresolver=cfdns"
+      - "traefik.http.routers.kbm-www.service=kbm-app"
+      - "traefik.http.routers.kbm-www.middlewares=kbm-wwwredirect"
+      - "traefik.http.middlewares.kbm-wwwredirect.redirectregex.regex=^https?://www\\.${BASE_DOMAIN}/(.*)"
+      - "traefik.http.middlewares.kbm-wwwredirect.redirectregex.replacement=https://${BASE_DOMAIN}/$${1}"
+      - "traefik.http.middlewares.kbm-wwwredirect.redirectregex.permanent=true"
+
+      # Router: wildcard tenant subdomains (one *.${BASE_DOMAIN} cert via DNS-01).
+      - "traefik.http.routers.kbm-tenants.rule=HostRegexp(`^[a-z0-9-]+\\.${BASE_DOMAIN}$`)"
+      - "traefik.http.routers.kbm-tenants.priority=1"
+      - "traefik.http.routers.kbm-tenants.entrypoints=websecure"
+      - "traefik.http.routers.kbm-tenants.tls=true"
+      - "traefik.http.routers.kbm-tenants.tls.certresolver=cfdns"
+      - "traefik.http.routers.kbm-tenants.tls.domains[0].main=${BASE_DOMAIN}"
+      - "traefik.http.routers.kbm-tenants.tls.domains[0].sans=*.${BASE_DOMAIN}"
+      - "traefik.http.routers.kbm-tenants.service=kbm-app"
+      - "traefik.http.routers.kbm-tenants.middlewares=tenant-gate@docker"
+      # Host-network Traefik reaches the app via the loopback publish above.
+      - "traefik.http.middlewares.tenant-gate.forwardauth.address=http://127.0.0.1:8000/_internal/check-domain?secret=${INTERNAL_API_SECRET}"
+      - "traefik.http.middlewares.tenant-gate.forwardauth.trustForwardHeader=true"


### PR DESCRIPTION
## What
Adds `compose.external-traefik.yaml`, a compose override for running KBM behind an **existing external Traefik** already on the host — the case where a shared, host-network Traefik owns ports 80/443 and fronts multiple apps, so KBM can run neither Caddy nor its own bundled Traefik (`compose.traefik.yaml`).

This is what the production VPS (`buywithvesta.com`) now uses.

## How it works
Enable with:
```
COMPOSE_FILE=compose.yaml:compose.external-traefik.yaml
```
The override:
- disables Caddy (`profiles: ["disabled"]`)
- publishes the app on `127.0.0.1:8000` so a host-network Traefik can reach the `tenant-gate` forwardauth (it can't resolve `python-app` over docker DNS)
- emits the full router set — `kbm-root` (apex), `kbm-www` (308→apex redirect), `kbm-tenants` (wildcard, forwardauth-gated) — using a **`cfdns`** Cloudflare DNS-01 resolver, with explicit priorities so apex/www are never gated as tenants

## Durability
The in-app updater records the active `config_files` from the running container's compose labels and reconstructs the same merge on every `up -d`; `compose.yaml` stays pristine so auto-stash / `reset --hard` reverts nothing. Verified that both the in-app updater path and a Hostinger-side redeploy preserve the merge (Caddy does not come back).

## External Traefik prerequisite
The shared Traefik must define a `cfdns` Cloudflare DNS-01 resolver (alongside its existing resolver) and receive `CF_DNS_API_TOKEN`. Documented in `TRAEFIK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)