### PR TITLE
Add REST API v1 with token auth, full resource coverage, and developer docs

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,406 @@
+# KBM API Documentation
+
+Integration guide for the KBM REST API — connect your own apps, scripts,
+Zapier/Make workflows, or property-management tools to KBM.
+
+**Live, always-current references** (served by the app itself):
+
+- **Interactive docs**: `https://<your-subdomain>.<your-domain>/api/v1/docs`
+- **OpenAPI 3.0 spec**: `https://<your-subdomain>.<your-domain>/api/v1/openapi.json`
+  (import this into Postman, Insomnia, or a code generator)
+
+This document is the narrative companion: concepts, auth walkthrough, and
+copy-paste examples.
+
+---
+
+## 1. The Basics
+
+### Base URL
+
+Every tenant (company) has its own subdomain, and the API is scoped the same
+way as the web app:
+
+```
+https://<your-subdomain>.<your-domain>/api/v1
+```
+
+Calling a tenant endpoint on the wrong subdomain returns `403 wrong_tenant`;
+calling it on the root domain returns `404 tenant_required`.
+
+### Content type
+
+Send request bodies as JSON with `Content-Type: application/json`. All
+responses are JSON.
+
+### Versioning
+
+The API is versioned in the URL (`/api/v1`). Backwards-incompatible changes
+will ship as `/api/v2`; `v1` responses may gain *new* fields at any time, so
+parse leniently.
+
+---
+
+## 2. Authentication
+
+### Step 1 — create a token
+
+Exchange your normal KBM login (email + PIN) for a long-lived API token.
+This is the only endpoint that takes credentials; it is rate-limited
+(10/minute, 30/hour).
+
+```bash
+curl -X POST https://acme.example.com/api/v1/auth/tokens \
+  -H "Content-Type: application/json" \
+  -d '{
+        "email": "you@acme.com",
+        "pin": "1234",
+        "name": "zapier-integration",
+        "expires_in_days": 365
+      }'
+```
+
+```json
+{
+  "id": 7,
+  "name": "zapier-integration",
+  "token": "kbm_1a2b3c4d_Xy9...longsecret...",
+  "token_prefix": "1a2b3c4d",
+  "expires_at": "2027-07-13T00:00:00",
+  "created_at": "2026-07-13T18:04:00",
+  "last_used_at": null,
+  "revoked": false
+}
+```
+
+> ⚠️ **The `token` value is shown exactly once.** Store it in a secret
+> manager. Only a hash is kept server-side; a lost token cannot be
+> recovered — revoke it and create a new one.
+
+`name` and `expires_in_days` are optional (`expires_in_days` omitted = the
+token never expires). Each user can hold up to 25 active tokens.
+
+### Step 2 — use it
+
+Send the token on every request:
+
+```
+Authorization: Bearer kbm_1a2b3c4d_Xy9...
+```
+
+Tokens inherit the **role of the user who created them**:
+
+| Role | Can |
+|------|-----|
+| user / staff / agent | Read everything, create/update records, checkout/checkin/assign |
+| admin / owner | All of the above + deletes, user management, settings, activity logs |
+| app_admin | Cross-tenant access + `GET /accounts` on the root domain |
+
+### Managing tokens
+
+```bash
+# List tokens (admins see the whole account's tokens)
+curl https://acme.example.com/api/v1/auth/tokens -H "Authorization: Bearer $TOKEN"
+
+# Revoke one (takes effect immediately)
+curl -X DELETE https://acme.example.com/api/v1/auth/tokens/7 -H "Authorization: Bearer $TOKEN"
+
+# Sanity-check your credentials
+curl https://acme.example.com/api/v1/me -H "Authorization: Bearer $TOKEN"
+```
+
+Deactivating a user in KBM instantly invalidates all of their tokens.
+
+---
+
+## 3. Conventions
+
+### Errors
+
+Every error is JSON with a stable machine-readable code:
+
+```json
+{ "error": { "code": "no_copies_available", "message": "Invalid number of copies. Available: 2." } }
+```
+
+| HTTP | Typical codes |
+|------|---------------|
+| 400 | `invalid_json`, `invalid_field`, `unknown_fields`, `missing_credentials` |
+| 401 | `missing_token`, `invalid_token`, `token_revoked`, `user_inactive`, `invalid_credentials` |
+| 403 | `wrong_tenant`, `admin_required`, `forbidden` |
+| 404 | `not_found`, `tenant_required` |
+| 409 | `duplicate_custom_id`, `duplicate_email`, `no_copies_available`, `item_in_use`, `property_in_use`, `contact_in_use`, `token_limit`, `user_limit` |
+| 429 | `rate_limited` |
+
+### Pagination
+
+All list endpoints accept `page` (default 1) and `per_page` (default 25,
+max 100) and return:
+
+```json
+{
+  "items": [ ... ],
+  "pagination": { "page": 1, "per_page": 25, "total": 132, "pages": 6 }
+}
+```
+
+### Dates
+
+Send dates as `YYYY-MM-DD` (or full ISO-8601). All returned timestamps are
+naive UTC ISO-8601.
+
+### Item references
+
+Anywhere the path contains `{item_ref}` you may use **either** the numeric
+database id (`42`) or the human-facing custom id (`KA042`, `LBA001`,
+`SA003`) — case-insensitive.
+
+---
+
+## 4. Resources
+
+### Items (keys, lockboxes, signs)
+
+```
+GET    /items                      list — filters: type, status, q, property_id, assigned_to
+POST   /items                      create ('type' + 'label' required; custom_id auto-generated)
+GET    /items/{item_ref}           detail incl. active_checkouts
+PATCH  /items/{item_ref}           update descriptive fields
+DELETE /items/{item_ref}           admin; blocked while checked out / assigned
+POST   /items/{item_ref}/checkout
+POST   /items/{item_ref}/checkin
+POST   /items/{item_ref}/assign
+```
+
+`status` is managed by the action endpoints — you cannot PATCH it. Each type
+accepts only its own fields (`unknown_fields` otherwise):
+
+| Type | Extra writable fields |
+|------|----------------------|
+| all | `label`, `location`, `address`, `assigned_to` |
+| Lockbox | `code_current`, `code_previous`, `supra_id` |
+| Key | `key_hook_number`, `keycode`, `total_copies`, `checkout_purpose`, `master_key_id` |
+| Sign | `sign_subtype` (Piece \| Assembled Unit), `piece_type`, `rider_text`, `material`, `condition` |
+
+**Create a key:**
+
+```bash
+curl -X POST https://acme.example.com/api/v1/items \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"type": "Key", "label": "Front Door — 123 Main St", "total_copies": 5, "key_hook_number": "H12"}'
+```
+
+**Check out 2 copies of a key** (creates a checkout record; sends the
+tenant's usual email notification if the contact has an email):
+
+```bash
+curl -X POST https://acme.example.com/api/v1/items/KA001/checkout \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"copies": 2, "checked_out_to": "Jane Contractor", "purpose": "Showing",
+       "expected_return_date": "2026-07-20", "contact_id": 14}'
+```
+
+Returns `201` with `item` and the `checkout` record — keep `checkout.id` to
+check that specific loan back in:
+
+```bash
+curl -X POST https://acme.example.com/api/v1/items/KA001/checkin \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"checkout_id": 55}'
+```
+
+**Lockboxes require the current code on checkout *and* check-in** — the API
+rotates `code_current` → `code_previous` exactly like the web app:
+
+```bash
+curl -X POST https://acme.example.com/api/v1/items/LBA001/checkout \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"code": "4482", "assigned_to": "Agent Bob", "address": "123 Main St"}'
+```
+
+**Assignments** (longer-term than a checkout). Keys require
+`assignment_type` = `tenant` | `contractor` | `property`; contractor
+assignments require `expected_return_date`; property assignments require
+`property_id` (and `assigned_to` defaults to the property's name):
+
+```bash
+curl -X POST https://acme.example.com/api/v1/items/KA001/assign \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"assignment_type": "property", "property_id": 3, "copies": 1}'
+```
+
+### Checkouts (history)
+
+```
+GET /checkouts        filters: active, overdue, item_id, contact_id, person
+GET /checkouts/{id}
+```
+
+`GET /checkouts?overdue=true` is the one to poll for reminder workflows —
+active checkouts past their expected return date.
+
+### Properties & units
+
+```
+GET/POST   /properties                     (q filter searches name/address/city)
+GET/PATCH/DELETE /properties/{id}          (GET includes units + item counts)
+GET/POST   /properties/{id}/units
+GET/PATCH/DELETE /units/{unit_id}
+```
+
+`name` and `address_line1` are required on create. Deleting is blocked while
+items are linked (`409 property_in_use`).
+
+### Contacts
+
+```
+GET/POST   /contacts                       (q searches name/company/email/phone; type filter)
+GET/PATCH/DELETE /contacts/{id}            (GET includes active_checkouts)
+```
+
+Pass a `contact_id` when checking out keys to link the loan to a contact —
+that link powers email notifications and the contact's checkout history.
+
+### Smart locks
+
+```
+GET/POST   /smart-locks                    (q, property_id filters)
+GET/PATCH/DELETE /smart-locks/{id}         (GET includes image metadata)
+```
+
+`label` and `code` are required. Image *uploads* are web-only.
+
+### Audits (read-only)
+
+```
+GET /audits                                (status filter: pending|in_progress|completed)
+GET /audits/{id}                           items + discrepancy_count
+```
+
+### Admin (admin/owner tokens)
+
+```
+GET/POST /users            PATCH/DELETE /users/{id}     manage account users
+GET/PATCH /settings                                     tenant settings (notifications, thresholds, receipts)
+GET /activity-logs                                      filters: action, user_id, target_type
+GET /stats                                              item counts by type/status + active/overdue checkouts
+```
+
+### App admin (root domain)
+
+```
+GET /accounts                                           list all tenant accounts
+```
+
+---
+
+## 5. Client Examples
+
+### Python
+
+```python
+import requests
+
+class KBM:
+    def __init__(self, base, token):
+        self.base = f"{base}/api/v1"
+        self.s = requests.Session()
+        self.s.headers["Authorization"] = f"Bearer {token}"
+
+    def get(self, path, **params):
+        r = self.s.get(f"{self.base}{path}", params=params)
+        r.raise_for_status()
+        return r.json()
+
+    def post(self, path, **body):
+        r = self.s.post(f"{self.base}{path}", json=body)
+        r.raise_for_status()
+        return r.json()
+
+kbm = KBM("https://acme.example.com", "kbm_1a2b3c4d_...")
+
+# Everything overdue, for a daily Slack reminder
+overdue = kbm.get("/checkouts", overdue=True)["checkouts"]
+for c in overdue:
+    print(f"{c['item']['label']} — {c['checked_out_to']} (due {c['expected_return_date'][:10]})")
+
+# Check a key out to a contractor
+result = kbm.post("/items/KA001/checkout",
+                  copies=1, checked_out_to="Jane Contractor",
+                  expected_return_date="2026-07-20")
+print("Receipt/checkout id:", result["checkout"]["id"])
+```
+
+### JavaScript / Node
+
+```javascript
+const BASE = "https://acme.example.com/api/v1";
+const HEADERS = {
+  "Authorization": `Bearer ${process.env.KBM_TOKEN}`,
+  "Content-Type": "application/json",
+};
+
+async function kbm(path, options = {}) {
+  const res = await fetch(`${BASE}${path}`, { headers: HEADERS, ...options });
+  const body = await res.json();
+  if (!res.ok) throw new Error(`${body.error.code}: ${body.error.message}`);
+  return body;
+}
+
+// List available keys for a property
+const { items } = await kbm("/items?type=Key&status=available&property_id=3");
+
+// Create a property from your CRM
+await kbm("/properties", {
+  method: "POST",
+  body: JSON.stringify({
+    name: "Maple Apartments",
+    address_line1: "12 Maple St",
+    city: "Springfield",
+    state: "IL",
+  }),
+});
+```
+
+### PowerShell
+
+```powershell
+$headers = @{ Authorization = "Bearer $env:KBM_TOKEN" }
+$stats = Invoke-RestMethod "https://acme.example.com/api/v1/stats" -Headers $headers
+$stats.items
+```
+
+---
+
+## 6. Recipes
+
+**Nightly overdue report** — `GET /checkouts?overdue=true&per_page=100`,
+page through, notify.
+
+**Sync properties from your CRM** — `GET /properties?q=<address>` to check
+for an existing record, `POST /properties` when missing, `PATCH` when found.
+
+**Key kiosk / scanner app** — scan the printed custom id, then
+`GET /items/{scanned_id}` → show details → `POST .../checkout` or
+`.../checkin`. Custom ids resolve directly in the URL.
+
+**Dashboard widget** — `GET /stats` returns item counts by type/status plus
+active and overdue checkout counts in one call.
+
+**Deprovision an employee** — `PATCH /users/{id} {"is_active": false}`
+blocks their web login *and* kills their API tokens at once.
+
+---
+
+## 7. Operational Notes
+
+- **Audit trail**: every write through the API produces the same activity-log
+  entries as the web UI (visible under Activity Logs, `via: api` in the
+  metadata), attributed to the token's user.
+- **Rate limits**: only token creation is rate-limited today. Be a good
+  citizen anyway; batch where possible.
+- **Notifications**: key checkouts/check-ins trigger the tenant's configured
+  email notifications exactly like the web flows.
+- **HTTPS**: production deployments sit behind TLS; never send a token over
+  plain HTTP.
+- **Request size**: bodies are capped (16 MB default, `MAX_CONTENT_LENGTH`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Full REST API release.
   automatically on boot.
 - **API reference docs** at `/api/v1/docs` (interactive, self-contained)
   plus a machine-readable OpenAPI 3.0 spec at `/api/v1/openapi.json`.
+- **API integration guide** (`API_DOCUMENTATION.md`) for external apps:
+  auth walkthrough, conventions, per-resource examples in curl / Python /
+  JavaScript / PowerShell, and common integration recipes.
+- **"API & Integrations" Help Center topic** so admins can discover the
+  API and token management from inside the app.
 - **API test suite** (`tests/test_api.py`, 20 tests) exercising the token
   lifecycle, every resource family, role gating, and tenant isolation.
 - All API writes create the same activity-log entries as the web UI, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to KBM (Keybox Manager) are documented here.
 Versioning: MAJOR.MINOR.PATCH. The running version is shown in the app
 sidebar and defined as `APP_VERSION` in `config.py`.
 
+## [2.2.0] — 2026-07-13
+
+Full REST API release.
+
+### Added
+- **REST API v1** at `/api/v1` covering the whole app: items (lockboxes,
+  keys, signs) with checkout / check-in / assign actions that mirror the web
+  flows exactly, checkout history, properties + units, contacts, smart
+  locks, audits (read), users, tenant settings, activity logs, and an
+  inventory stats summary. App admins get a cross-tenant `/api/v1/accounts`
+  endpoint on the root domain.
+- **API tokens**: `POST /api/v1/auth/tokens` exchanges a login email + PIN
+  for a long-lived Bearer token (rate-limited; optional expiry; stored
+  hashed in the master DB, shown once). Tokens inherit the user's role;
+  list/revoke endpoints included. New `api_tokens` table is created
+  automatically on boot.
+- **API reference docs** at `/api/v1/docs` (interactive, self-contained)
+  plus a machine-readable OpenAPI 3.0 spec at `/api/v1/openapi.json`.
+- **API test suite** (`tests/test_api.py`, 20 tests) exercising the token
+  lifecycle, every resource family, role gating, and tenant isolation.
+- All API writes create the same activity-log entries as the web UI, and
+  key checkouts/check-ins trigger the same email notifications.
+- JSON error responses (`{"error": {"code", "message"}}`) for every `/api/`
+  path, including 404/405/429 raised outside the blueprint.
+
 ## [2.1.0] — 2026-07-02
 
 Deployment-readiness release: built-in Help Center, a round of bug fixes

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # KBM 2.0 - Key & Lockbox Management System
 
-![Version](https://img.shields.io/badge/version-2.1.0-blue) ![Status](https://img.shields.io/badge/status-production_ready-green) ![Security](https://img.shields.io/badge/security-hardened-brightgreen) ![Python](https://img.shields.io/badge/python-3.11+-blue)
+![Version](https://img.shields.io/badge/version-2.2.0-blue) ![Status](https://img.shields.io/badge/status-production_ready-green) ![Security](https://img.shields.io/badge/security-hardened-brightgreen) ![Python](https://img.shields.io/badge/python-3.11+-blue)
 
 **Multi-Tenant Property Management Solution**
 
 Complete web application for managing keys, lockboxes, signs, and smart locks for property management businesses.
 
-Current version: **2.1.0** — see [CHANGELOG.md](CHANGELOG.md) for the full version history.
+Current version: **2.2.0** — see [CHANGELOG.md](CHANGELOG.md) for the full version history.
 
 ---
 
@@ -53,9 +53,10 @@ python app_multitenant.py
 5. **[SYSTEM_UPDATES_GUIDE.md](SYSTEM_UPDATES_GUIDE.md)** - Web-based system update interface
 6. **[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)** - Technical architecture and code documentation
 7. **[USER_QUICKSTART_GUIDE.md](USER_QUICKSTART_GUIDE.md)** - End-user manual and feature guide
-8. **[DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md)** - Development process and guidelines
-9. **[BACKUP_GUIDE.md](BACKUP_GUIDE.md)** - Backup and restoration procedures
-10. **[ToDo.txt](ToDo.txt)** - Project tracking and fix history
+8. **[API_DOCUMENTATION.md](API_DOCUMENTATION.md)** - REST API integration guide for external apps (also served live at `/api/v1/docs`)
+9. **[DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md)** - Development process and guidelines
+10. **[BACKUP_GUIDE.md](BACKUP_GUIDE.md)** - Backup and restoration procedures
+11. **[ToDo.txt](ToDo.txt)** - Project tracking and fix history
 
 ---
 
@@ -84,6 +85,7 @@ See [ToDo.txt](ToDo.txt) REFERENCE section for complete fix history.
 - 🏢 **Properties** - Manage properties, units, contacts
 - 📊 **Reports** - Activity logs and analytics
 - 📥 **Import/Export** - Bulk operations with Excel
+- 🔌 **REST API** - Token-authenticated API at `/api/v1` for external integrations ([guide](API_DOCUMENTATION.md), live docs at `/api/v1/docs`)
 - ❓ **Built-in Help** - In-app Help Center with per-page context help and tooltips
 - 🔒 **Secure** - CSRF, login rate limiting, hardened sessions
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,29 @@
+"""REST API v1 for KBM.
+
+All endpoints live under /api/v1 (registered in app_multitenant.py) and are
+authenticated with Bearer tokens (see api/helpers.py). Tenant-scoped
+endpoints must be called on the tenant's subdomain, exactly like the web UI.
+
+Route modules attach themselves to api_bp on import.
+"""
+
+from flask import Blueprint
+
+api_bp = Blueprint("api", __name__)
+
+from api.helpers import register_error_handlers  # noqa: E402
+
+register_error_handlers(api_bp)
+
+# Import route modules for their side effect of registering routes.
+from api import routes_meta  # noqa: E402,F401
+from api import routes_tokens  # noqa: E402,F401
+from api import routes_items  # noqa: E402,F401
+from api import routes_checkouts  # noqa: E402,F401
+from api import routes_properties  # noqa: E402,F401
+from api import routes_contacts  # noqa: E402,F401
+from api import routes_smartlocks  # noqa: E402,F401
+from api import routes_audits  # noqa: E402,F401
+from api import routes_admin  # noqa: E402,F401
+
+__all__ = ["api_bp"]

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1,0 +1,233 @@
+"""Shared plumbing for the REST API: auth, errors, pagination, parsing."""
+
+import hmac
+from datetime import datetime
+from functools import wraps
+from typing import Any, Dict, Optional, Tuple
+
+from flask import g, jsonify, request
+
+from utilities.master_database import master_db, ApiToken, MasterUser
+from utilities.tenant_manager import tenant_manager
+from utilities.database import utc_now
+
+ADMIN_ROLES = ("admin", "owner", "app_admin")
+
+
+# --- Errors -----------------------------------------------------------------
+
+class ApiError(Exception):
+    """Raise anywhere in an API handler to produce a structured JSON error."""
+
+    def __init__(self, status: int, code: str, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = details
+
+    def to_response(self):
+        body = {"error": {"code": self.code, "message": self.message}}
+        if self.details:
+            body["error"]["details"] = self.details
+        return jsonify(body), self.status
+
+
+def error(status: int, code: str, message: str, details: Optional[Dict[str, Any]] = None) -> ApiError:
+    return ApiError(status, code, message, details)
+
+
+def register_error_handlers(bp):
+    @bp.errorhandler(ApiError)
+    def _handle_api_error(exc: ApiError):
+        return exc.to_response()
+
+
+# --- Auth -------------------------------------------------------------------
+
+def _extract_bearer_token() -> Optional[str]:
+    header = request.headers.get("Authorization", "")
+    if header.lower().startswith("bearer "):
+        return header[7:].strip() or None
+    # Fallback for clients that can't set headers (e.g. webhook test tools)
+    return request.args.get("api_token") or None
+
+
+def _resolve_token(raw: str) -> Tuple[ApiToken, MasterUser]:
+    # Token format: kbm_<prefix>_<secret>
+    parts = raw.split("_", 2)
+    if len(parts) != 3 or parts[0] != ApiToken.TOKEN_ENV_PREFIX:
+        raise error(401, "invalid_token", "Malformed API token.")
+
+    token = ApiToken.query.filter_by(token_prefix=parts[1]).first()
+    if token is None or not hmac.compare_digest(token.token_hash, ApiToken.hash_raw(raw)):
+        raise error(401, "invalid_token", "Unknown or invalid API token.")
+    if not token.is_valid():
+        raise error(401, "token_revoked", "This API token has been revoked or has expired.")
+
+    user = master_db.session.get(MasterUser, token.user_id)
+    if user is None or not user.is_active:
+        raise error(401, "user_inactive", "The user this token belongs to is inactive.")
+
+    return token, user
+
+
+def api_auth_required(f):
+    """Authenticate the request with a Bearer token.
+
+    Sets g.api_token and g.api_user. Does NOT require a tenant context —
+    use api_tenant_required for tenant-scoped endpoints.
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        raw = _extract_bearer_token()
+        if not raw:
+            raise error(401, "missing_token",
+                        "Provide an API token via the 'Authorization: Bearer <token>' header.")
+        token, user = _resolve_token(raw)
+
+        g.api_token = token
+        g.api_user = user
+
+        token.last_used_at = utc_now()
+        try:
+            master_db.session.commit()
+        except Exception:
+            master_db.session.rollback()
+
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def api_tenant_required(f):
+    """Bearer auth + require a tenant subdomain the token is allowed to use.
+
+    A tenant token only works on its own account's subdomain. App-admin
+    tokens (account_id NULL) work on any active tenant subdomain.
+    """
+
+    @wraps(f)
+    @api_auth_required
+    def wrapper(*args, **kwargs):
+        tenant = tenant_manager.get_current_tenant()
+        if tenant is None:
+            raise error(404, "tenant_required",
+                        "This endpoint must be called on a company subdomain "
+                        "(e.g. https://yourcompany.example.com/api/v1/...).")
+
+        user = g.api_user
+        if (user.role or "").lower() != "app_admin" and user.account_id != tenant.id:
+            raise error(403, "wrong_tenant", "This API token does not belong to this company.")
+
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+def require_admin():
+    """Abort with 403 unless the token's user is an admin/owner/app_admin."""
+    role = (getattr(g.api_user, "role", "") or "").lower()
+    if role not in ADMIN_ROLES:
+        raise error(403, "admin_required", "This endpoint requires an admin role.")
+
+
+# --- Request parsing ---------------------------------------------------------
+
+def get_json_body() -> Dict[str, Any]:
+    body = request.get_json(silent=True)
+    if body is None:
+        # Tolerate empty bodies on endpoints where every field is optional.
+        if not request.data:
+            return {}
+        raise error(400, "invalid_json", "Request body must be valid JSON (Content-Type: application/json).")
+    if not isinstance(body, dict):
+        raise error(400, "invalid_json", "Request body must be a JSON object.")
+    return body
+
+
+def clean_str(value: Any, field: str, max_length: Optional[int] = None) -> Optional[str]:
+    """Coerce a JSON value to a stripped string or None."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise error(400, "invalid_field", f"'{field}' must be a string.")
+    value = value.strip()
+    if max_length and len(value) > max_length:
+        raise error(400, "invalid_field", f"'{field}' must be at most {max_length} characters.")
+    return value or None
+
+
+def clean_int(value: Any, field: str) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise error(400, "invalid_field", f"'{field}' must be an integer.")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise error(400, "invalid_field", f"'{field}' must be an integer.")
+
+
+def clean_bool(value: Any, field: str) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "1", "yes"):
+            return True
+        if lowered in ("false", "0", "no"):
+            return False
+    raise error(400, "invalid_field", f"'{field}' must be a boolean.")
+
+
+def parse_date(value: Any, field: str) -> Optional[datetime]:
+    """Accept 'YYYY-MM-DD' or full ISO-8601 datetimes."""
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise error(400, "invalid_field", f"'{field}' must be a date string (YYYY-MM-DD).")
+    value = value.strip()
+    for fmt in ("%Y-%m-%d",):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            pass
+    try:
+        parsed = datetime.fromisoformat(value)
+        return parsed.replace(tzinfo=None)
+    except ValueError:
+        raise error(400, "invalid_field", f"'{field}' is not a valid date. Use YYYY-MM-DD or ISO-8601.")
+
+
+# --- Pagination ---------------------------------------------------------------
+
+MAX_PER_PAGE = 100
+DEFAULT_PER_PAGE = 25
+
+
+def paginate(query):
+    """Apply ?page=&per_page= to a query; return (rows, meta dict)."""
+    page = request.args.get("page", 1, type=int) or 1
+    per_page = request.args.get("per_page", DEFAULT_PER_PAGE, type=int) or DEFAULT_PER_PAGE
+    page = max(page, 1)
+    per_page = min(max(per_page, 1), MAX_PER_PAGE)
+
+    total = query.count()
+    rows = query.offset((page - 1) * per_page).limit(per_page).all()
+    pages = (total + per_page - 1) // per_page if total else 0
+
+    meta = {
+        "page": page,
+        "per_page": per_page,
+        "total": total,
+        "pages": pages,
+    }
+    return rows, meta
+
+
+def list_response(key: str, rows, meta):
+    return jsonify({key: [r.to_dict() for r in rows], "pagination": meta})

--- a/api/openapi.py
+++ b/api/openapi.py
@@ -1,0 +1,345 @@
+"""OpenAPI 3.0 spec for the KBM API, built as plain data.
+
+Kept deliberately compact: helper functions generate the repetitive parts
+(pagination params, standard error responses, CRUD path items).
+"""
+
+from config import APP_VERSION
+
+BEARER = [{"bearerAuth": []}]
+
+PAGINATION_PARAMS = [
+    {"name": "page", "in": "query", "schema": {"type": "integer", "default": 1}},
+    {"name": "per_page", "in": "query", "schema": {"type": "integer", "default": 25, "maximum": 100}},
+]
+
+
+def _resp(description, status="200"):
+    return {status: {"description": description}}
+
+
+def _errors(*statuses):
+    messages = {
+        "400": "Validation error",
+        "401": "Missing or invalid token",
+        "403": "Insufficient permissions",
+        "404": "Not found",
+        "409": "Conflict (state prevents the operation)",
+        "429": "Rate limited",
+    }
+    return {s: {"description": messages[s]} for s in statuses}
+
+
+def _op(summary, *, tag, params=None, body=None, responses=None, security=True, description=None):
+    op = {"summary": summary, "tags": [tag], "responses": responses or _resp("OK")}
+    if description:
+        op["description"] = description
+    if params:
+        op["parameters"] = params
+    if body:
+        op["requestBody"] = {
+            "required": True,
+            "content": {"application/json": {"schema": body}},
+        }
+    if security:
+        op["security"] = BEARER
+    return op
+
+
+def _obj(props, required=None):
+    schema = {"type": "object", "properties": props}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+S = {"type": "string"}
+I = {"type": "integer"}
+B = {"type": "boolean"}
+N = {"type": "number"}
+DATE = {"type": "string", "format": "date", "description": "YYYY-MM-DD or ISO-8601"}
+
+
+def build_spec():
+    id_param = lambda name, desc: {"name": name, "in": "path", "required": True, "schema": S if name == "item_ref" else I, "description": desc}  # noqa: E731
+
+    item_ref = id_param("item_ref", "Numeric item id or custom id (e.g. KA042)")
+
+    paths = {}
+
+    # --- Meta / auth ---
+    paths["/"] = {"get": _op("API index and orientation", tag="Meta", security=False)}
+    paths["/me"] = {"get": _op("Identify the current token's user", tag="Meta")}
+    paths["/auth/tokens"] = {
+        "post": _op(
+            "Create an API token (email + PIN)",
+            tag="Auth", security=False,
+            description="Call on your company subdomain. App admins call on the root domain. "
+                        "The raw token is returned exactly once. Rate limited.",
+            body=_obj({"email": S, "pin": S, "name": S, "expires_in_days": I}, ["email", "pin"]),
+            responses={**_resp("Token created (includes raw token)", "201"), **_errors("400", "401", "429")},
+        ),
+        "get": _op("List tokens (own; admins see the whole account)", tag="Auth"),
+    }
+    paths["/auth/tokens/{token_id}"] = {
+        "delete": _op("Revoke a token", tag="Auth",
+                      params=[id_param("token_id", "Token id")],
+                      responses={**_resp("Revoked"), **_errors("403", "404")}),
+    }
+
+    # --- Items ---
+    item_filters = PAGINATION_PARAMS + [
+        {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["Lockbox", "Key", "Sign"]}},
+        {"name": "status", "in": "query", "schema": {"type": "string", "enum": ["available", "checked_out", "assigned"]}},
+        {"name": "q", "in": "query", "schema": S, "description": "Search custom id, label, address, location"},
+        {"name": "property_id", "in": "query", "schema": I},
+        {"name": "assigned_to", "in": "query", "schema": S},
+    ]
+    item_body = _obj({
+        "type": {"type": "string", "enum": ["Lockbox", "Key", "Sign"]},
+        "label": S, "custom_id": S, "location": S, "address": S, "assigned_to": S,
+        "code_current": S, "code_previous": S, "supra_id": S,
+        "key_hook_number": S, "keycode": S, "total_copies": I, "checkout_purpose": S, "master_key_id": I,
+        "sign_subtype": {"type": "string", "enum": ["Piece", "Assembled Unit"]},
+        "piece_type": S, "rider_text": S, "material": S, "condition": S,
+        "property_id": I, "property_unit_id": I,
+    })
+    paths["/items"] = {
+        "get": _op("List items", tag="Items", params=item_filters),
+        "post": _op("Create an item", tag="Items",
+                    description="'type' and 'label' are required. custom_id is auto-generated when omitted. "
+                                "Only fields valid for the item's type are accepted.",
+                    body={**item_body, "required": ["type", "label"]},
+                    responses={**_resp("Created", "201"), **_errors("400", "409")}),
+    }
+    paths["/items/{item_ref}"] = {
+        "get": _op("Get an item (includes active checkouts)", tag="Items", params=[item_ref],
+                   responses={**_resp("OK"), **_errors("404")}),
+        "patch": _op("Update an item", tag="Items", params=[item_ref], body=item_body,
+                     responses={**_resp("Updated"), **_errors("400", "404", "409")}),
+        "delete": _op("Delete an item (admin)", tag="Items", params=[item_ref],
+                      responses={**_resp("Deleted"), **_errors("403", "404", "409")}),
+    }
+    paths["/items/{item_ref}/checkout"] = {
+        "post": _op("Check out an item", tag="Items", params=[item_ref],
+                    description="Keys: {copies, checked_out_to, purpose, expected_return_date, contact_id}. "
+                                "Lockboxes: {code (required — rotates stored code), assigned_to, location, address}. "
+                                "Signs: {purpose, assigned_to, location, address}.",
+                    body=_obj({"copies": I, "checked_out_to": S, "purpose": S,
+                               "expected_return_date": DATE, "contact_id": I,
+                               "code": S, "assigned_to": S, "location": S, "address": S}),
+                    responses={**_resp("Checked out"), **_resp("Checked out (key — returns checkout record)", "201"),
+                               **_errors("400", "404", "409")}),
+    }
+    paths["/items/{item_ref}/checkin"] = {
+        "post": _op("Check in an item", tag="Items", params=[item_ref],
+                    description="Keys: provide {checkout_id} (preferred) or {copies}; assigned keys "
+                                "check in fully when both are omitted. Lockboxes: {code required}. Signs: no body needed.",
+                    body=_obj({"checkout_id": I, "copies": I, "code": S, "location": S, "address": S}),
+                    responses={**_resp("Checked in"), **_errors("400", "404", "409")}),
+    }
+    paths["/items/{item_ref}/assign"] = {
+        "post": _op("Assign an item", tag="Items", params=[item_ref],
+                    description="Keys require 'assignment_type' (tenant|contractor|property) and consume copies. "
+                                "Contractor assignments require expected_return_date. Property assignments "
+                                "require property_id (assigned_to defaults to the property name).",
+                    body=_obj({"assigned_to": S, "assignment_type": {"type": "string", "enum": ["tenant", "contractor", "property"]},
+                               "copies": I, "expected_return_date": DATE, "property_id": I,
+                               "property_unit_id": I, "contact_id": I, "location": S, "address": S}),
+                    responses={**_resp("Assigned"), **_resp("Assigned (key — returns checkout record)", "201"),
+                               **_errors("400", "404", "409")}),
+    }
+
+    # --- Checkouts ---
+    paths["/checkouts"] = {
+        "get": _op("List checkout/assignment history", tag="Checkouts",
+                   params=PAGINATION_PARAMS + [
+                       {"name": "active", "in": "query", "schema": B},
+                       {"name": "overdue", "in": "query", "schema": B},
+                       {"name": "item_id", "in": "query", "schema": I},
+                       {"name": "contact_id", "in": "query", "schema": I},
+                       {"name": "person", "in": "query", "schema": S},
+                   ]),
+    }
+    paths["/checkouts/{checkout_id}"] = {
+        "get": _op("Get a checkout record", tag="Checkouts",
+                   params=[id_param("checkout_id", "Checkout id")],
+                   responses={**_resp("OK"), **_errors("404")}),
+    }
+
+    # --- Properties ---
+    prop_body = _obj({
+        "name": S, "type": S, "address_line1": S, "address_line2": S, "city": S,
+        "state": S, "postal_code": S, "country": S, "latitude": N, "longitude": N, "notes": S,
+    })
+    paths["/properties"] = {
+        "get": _op("List properties", tag="Properties",
+                   params=PAGINATION_PARAMS + [{"name": "q", "in": "query", "schema": S}]),
+        "post": _op("Create a property", tag="Properties",
+                    body={**prop_body, "required": ["name", "address_line1"]},
+                    responses={**_resp("Created", "201"), **_errors("400")}),
+    }
+    paths["/properties/{property_id}"] = {
+        "get": _op("Get a property (includes units and counts)", tag="Properties",
+                   params=[id_param("property_id", "Property id")], responses={**_resp("OK"), **_errors("404")}),
+        "patch": _op("Update a property", tag="Properties",
+                     params=[id_param("property_id", "Property id")], body=prop_body,
+                     responses={**_resp("Updated"), **_errors("400", "404")}),
+        "delete": _op("Delete a property (admin)", tag="Properties",
+                      params=[id_param("property_id", "Property id")],
+                      responses={**_resp("Deleted"), **_errors("403", "404", "409")}),
+    }
+    unit_body = _obj({"label": S, "floor": S, "bedrooms": I, "bathrooms": N, "square_feet": I, "notes": S})
+    paths["/properties/{property_id}/units"] = {
+        "get": _op("List a property's units", tag="Properties", params=[id_param("property_id", "Property id")]),
+        "post": _op("Add a unit to a property", tag="Properties",
+                    params=[id_param("property_id", "Property id")],
+                    body={**unit_body, "required": ["label"]},
+                    responses={**_resp("Created", "201"), **_errors("400", "404")}),
+    }
+    paths["/units/{unit_id}"] = {
+        "get": _op("Get a unit", tag="Properties", params=[id_param("unit_id", "Unit id")],
+                   responses={**_resp("OK"), **_errors("404")}),
+        "patch": _op("Update a unit", tag="Properties", params=[id_param("unit_id", "Unit id")], body=unit_body,
+                     responses={**_resp("Updated"), **_errors("400", "404")}),
+        "delete": _op("Delete a unit (admin)", tag="Properties", params=[id_param("unit_id", "Unit id")],
+                      responses={**_resp("Deleted"), **_errors("403", "404", "409")}),
+    }
+
+    # --- Contacts ---
+    contact_body = _obj({"contact_type": S, "name": S, "company": S, "email": S, "phone": S, "notes": S})
+    paths["/contacts"] = {
+        "get": _op("List contacts", tag="Contacts",
+                   params=PAGINATION_PARAMS + [
+                       {"name": "q", "in": "query", "schema": S},
+                       {"name": "type", "in": "query", "schema": S},
+                   ]),
+        "post": _op("Create a contact", tag="Contacts",
+                    body={**contact_body, "required": ["name"]},
+                    responses={**_resp("Created", "201"), **_errors("400")}),
+    }
+    paths["/contacts/{contact_id}"] = {
+        "get": _op("Get a contact (includes active checkouts)", tag="Contacts",
+                   params=[id_param("contact_id", "Contact id")], responses={**_resp("OK"), **_errors("404")}),
+        "patch": _op("Update a contact", tag="Contacts",
+                     params=[id_param("contact_id", "Contact id")], body=contact_body,
+                     responses={**_resp("Updated"), **_errors("400", "404")}),
+        "delete": _op("Delete a contact (admin)", tag="Contacts",
+                      params=[id_param("contact_id", "Contact id")],
+                      responses={**_resp("Deleted"), **_errors("403", "404", "409")}),
+    }
+
+    # --- Smart locks ---
+    lock_body = _obj({
+        "label": S, "provider": S, "code": S, "backup_code": S, "instructions": S, "notes": S,
+        "model_number": S, "serial_number": S, "pairing_code": S, "qr_code_data": S,
+        "property_id": I, "property_unit_id": I,
+    })
+    paths["/smart-locks"] = {
+        "get": _op("List smart locks", tag="Smart Locks",
+                   params=PAGINATION_PARAMS + [
+                       {"name": "q", "in": "query", "schema": S},
+                       {"name": "property_id", "in": "query", "schema": I},
+                   ]),
+        "post": _op("Create a smart lock", tag="Smart Locks",
+                    body={**lock_body, "required": ["label", "code"]},
+                    responses={**_resp("Created", "201"), **_errors("400")}),
+    }
+    paths["/smart-locks/{lock_id}"] = {
+        "get": _op("Get a smart lock (includes image metadata)", tag="Smart Locks",
+                   params=[id_param("lock_id", "Smart lock id")], responses={**_resp("OK"), **_errors("404")}),
+        "patch": _op("Update a smart lock", tag="Smart Locks",
+                     params=[id_param("lock_id", "Smart lock id")], body=lock_body,
+                     responses={**_resp("Updated"), **_errors("400", "404")}),
+        "delete": _op("Delete a smart lock (admin)", tag="Smart Locks",
+                      params=[id_param("lock_id", "Smart lock id")],
+                      responses={**_resp("Deleted"), **_errors("403", "404")}),
+    }
+
+    # --- Audits ---
+    paths["/audits"] = {
+        "get": _op("List audits", tag="Audits",
+                   params=PAGINATION_PARAMS + [{"name": "status", "in": "query",
+                                                "schema": {"type": "string", "enum": ["pending", "in_progress", "completed"]}}]),
+    }
+    paths["/audits/{audit_id}"] = {
+        "get": _op("Get an audit with its items and discrepancies", tag="Audits",
+                   params=[id_param("audit_id", "Audit id")], responses={**_resp("OK"), **_errors("404")}),
+    }
+
+    # --- Admin ---
+    user_body = _obj({"name": S, "email": S, "pin": S,
+                      "role": {"type": "string", "enum": list(("admin", "owner", "user", "staff", "agent"))},
+                      "is_active": B})
+    paths["/users"] = {
+        "get": _op("List account users (admin)", tag="Admin"),
+        "post": _op("Create a user (admin)", tag="Admin",
+                    body={**user_body, "required": ["name", "email", "pin"]},
+                    responses={**_resp("Created", "201"), **_errors("400", "403", "409")}),
+    }
+    paths["/users/{user_id}"] = {
+        "get": _op("Get a user (admin)", tag="Admin", params=[id_param("user_id", "User id")],
+                   responses={**_resp("OK"), **_errors("403", "404")}),
+        "patch": _op("Update a user (admin)", tag="Admin",
+                     params=[id_param("user_id", "User id")], body=user_body,
+                     responses={**_resp("Updated"), **_errors("400", "403", "404", "409")}),
+        "delete": _op("Delete a user (admin)", tag="Admin", params=[id_param("user_id", "User id")],
+                      responses={**_resp("Deleted"), **_errors("400", "403", "404")}),
+    }
+    paths["/settings"] = {
+        "get": _op("Get tenant settings (admin)", tag="Admin"),
+        "patch": _op("Update tenant settings (admin)", tag="Admin",
+                     body=_obj({
+                         "email_notifications_enabled": B, "notify_on_checkout": B,
+                         "notify_on_checkin": B, "notify_on_overdue": B,
+                         "overdue_grace_days": I, "low_keys_threshold": I,
+                         "default_checkout_days": I, "receipt_header": S, "receipt_footer": S,
+                     }),
+                     responses={**_resp("Updated"), **_errors("400", "403")}),
+    }
+    paths["/activity-logs"] = {
+        "get": _op("List activity logs (admin)", tag="Admin",
+                   params=PAGINATION_PARAMS + [
+                       {"name": "action", "in": "query", "schema": S},
+                       {"name": "user_id", "in": "query", "schema": I},
+                       {"name": "target_type", "in": "query", "schema": S},
+                   ]),
+    }
+    paths["/stats"] = {
+        "get": _op("Inventory summary: counts by type/status, active + overdue checkouts", tag="Admin"),
+    }
+    paths["/accounts"] = {
+        "get": _op("List all tenant accounts (app admin, root domain)", tag="Admin",
+                   responses={**_resp("OK"), **_errors("403")}),
+    }
+
+    return {
+        "openapi": "3.0.3",
+        "info": {
+            "title": "KBM API",
+            "version": APP_VERSION,
+            "description": (
+                "REST API for KBM (keys, lockboxes, signs, properties, contacts, smart locks).\n\n"
+                "**Base URL:** `https://<your-subdomain>.<domain>/api/v1` — tenant-scoped endpoints "
+                "must be called on your company subdomain, exactly like the web app.\n\n"
+                "**Authentication:** create a token with `POST /auth/tokens` using your login email "
+                "and PIN, then send `Authorization: Bearer <token>` on every request. Tokens inherit "
+                "your user's role; admin-only endpoints require an admin/owner token.\n\n"
+                "**Pagination:** list endpoints accept `page` and `per_page` (max 100) and return a "
+                "`pagination` object.\n\n"
+                "**Errors:** all errors are JSON: `{\"error\": {\"code\": ..., \"message\": ...}}`."
+            ),
+        },
+        "servers": [{"url": "/api/v1"}],
+        "tags": [
+            {"name": "Meta"}, {"name": "Auth"}, {"name": "Items"}, {"name": "Checkouts"},
+            {"name": "Properties"}, {"name": "Contacts"}, {"name": "Smart Locks"},
+            {"name": "Audits"}, {"name": "Admin"},
+        ],
+        "components": {
+            "securitySchemes": {
+                "bearerAuth": {"type": "http", "scheme": "bearer", "bearerFormat": "opaque"},
+            },
+        },
+        "paths": paths,
+    }

--- a/api/routes_admin.py
+++ b/api/routes_admin.py
@@ -1,0 +1,270 @@
+"""Admin-only endpoints: users, settings, activity logs, stats, accounts."""
+
+from flask import g, jsonify, request
+
+from api import api_bp
+from api.helpers import (
+    api_auth_required,
+    api_tenant_required,
+    clean_bool,
+    clean_int,
+    clean_str,
+    error,
+    get_json_body,
+    paginate,
+    require_admin,
+)
+from utilities.database import ActivityLog, Item, ItemCheckout, get_tenant_settings, log_activity, utc_now
+from utilities.master_database import master_db, Account, MasterUser
+from utilities.tenant_helpers import tenant_commit, tenant_query
+from utilities.tenant_manager import tenant_manager
+
+# Mirrors auth/views_multitenant.py — tenant-assignable roles.
+ALLOWED_ROLES = ("admin", "owner", "user", "staff", "agent")
+
+
+# --- Users --------------------------------------------------------------------
+
+def _get_account_user_or_404(user_id: int) -> MasterUser:
+    tenant = tenant_manager.get_current_tenant()
+    user = MasterUser.query.filter_by(id=user_id, account_id=tenant.id).first()
+    if user is None:
+        raise error(404, "not_found", f"User {user_id} not found in this account.")
+    return user
+
+
+def _validate_pin(pin) -> str | None:
+    if pin is None:
+        return None
+    pin = str(pin).strip()
+    if not pin:
+        return None
+    if len(pin) < 4:
+        raise error(400, "invalid_field", "'pin' must be at least 4 characters.")
+    return pin
+
+
+def _check_email_unique(email: str, account_id: int, exclude_user_id: int | None = None):
+    clash = MasterUser.query.filter(
+        master_db.func.lower(MasterUser.email) == email.lower(),
+        MasterUser.account_id == account_id,
+        MasterUser.id != (exclude_user_id or 0),
+    ).first()
+    if clash:
+        raise error(409, "duplicate_email", "A user with this email already exists in this account.")
+
+
+@api_bp.get("/users")
+@api_tenant_required
+def list_users():
+    require_admin()
+    tenant = tenant_manager.get_current_tenant()
+    users = MasterUser.query.filter_by(account_id=tenant.id).order_by(MasterUser.name.asc()).all()
+    return jsonify({"users": [u.to_dict() for u in users]})
+
+
+@api_bp.post("/users")
+@api_tenant_required
+def create_user():
+    require_admin()
+    tenant = tenant_manager.get_current_tenant()
+    body = get_json_body()
+
+    name = clean_str(body.get("name"), "name", 200)
+    email = clean_str(body.get("email"), "email", 255)
+    role = (clean_str(body.get("role"), "role", 20) or "user").lower()
+    pin = _validate_pin(body.get("pin"))
+
+    if not name:
+        raise error(400, "invalid_field", "'name' is required.")
+    if not email:
+        raise error(400, "invalid_field", "'email' is required.")
+    if not pin:
+        raise error(400, "invalid_field", "'pin' is required.")
+    if role not in ALLOWED_ROLES:
+        raise error(400, "invalid_field", f"'role' must be one of: {', '.join(ALLOWED_ROLES)}.")
+    _check_email_unique(email, tenant.id)
+
+    max_users = tenant.max_users or 0
+    if max_users:
+        current = MasterUser.query.filter_by(account_id=tenant.id).count()
+        if current >= max_users:
+            raise error(409, "user_limit", f"This account has reached its user limit ({max_users}).")
+
+    user = MasterUser(account_id=tenant.id, name=name, email=email, role=role, is_active=True)
+    user.set_pin(pin)
+    master_db.session.add(user)
+    master_db.session.commit()
+    return jsonify(user.to_dict()), 201
+
+
+@api_bp.get("/users/<int:user_id>")
+@api_tenant_required
+def get_user(user_id: int):
+    require_admin()
+    return jsonify(_get_account_user_or_404(user_id).to_dict())
+
+
+@api_bp.patch("/users/<int:user_id>")
+@api_tenant_required
+def update_user(user_id: int):
+    require_admin()
+    tenant = tenant_manager.get_current_tenant()
+    user = _get_account_user_or_404(user_id)
+    body = get_json_body()
+
+    if "name" in body:
+        name = clean_str(body.get("name"), "name", 200)
+        if not name:
+            raise error(400, "invalid_field", "'name' cannot be blank.")
+        user.name = name
+    if "email" in body:
+        email = clean_str(body.get("email"), "email", 255)
+        if not email:
+            raise error(400, "invalid_field", "'email' cannot be blank.")
+        _check_email_unique(email, tenant.id, exclude_user_id=user.id)
+        user.email = email
+    if "role" in body:
+        role = (clean_str(body.get("role"), "role", 20) or "").lower()
+        if role not in ALLOWED_ROLES:
+            raise error(400, "invalid_field", f"'role' must be one of: {', '.join(ALLOWED_ROLES)}.")
+        user.role = role
+    if "is_active" in body:
+        is_active = clean_bool(body.get("is_active"), "is_active")
+        if user.id == g.api_user.id and is_active is False:
+            raise error(400, "invalid_field", "You cannot deactivate your own account.")
+        user.is_active = bool(is_active)
+    if "pin" in body:
+        pin = _validate_pin(body.get("pin"))
+        if pin:
+            user.set_pin(pin)
+
+    master_db.session.commit()
+    return jsonify(user.to_dict())
+
+
+@api_bp.delete("/users/<int:user_id>")
+@api_tenant_required
+def delete_user(user_id: int):
+    require_admin()
+    if user_id == g.api_user.id:
+        raise error(400, "invalid_field", "You cannot remove your own account.")
+    user = _get_account_user_or_404(user_id)
+    master_db.session.delete(user)
+    master_db.session.commit()
+    return jsonify({"deleted": True, "id": user_id})
+
+
+# --- Settings -------------------------------------------------------------------
+
+SETTINGS_BOOL_FIELDS = ("email_notifications_enabled", "notify_on_checkout",
+                        "notify_on_checkin", "notify_on_overdue")
+SETTINGS_INT_FIELDS = ("overdue_grace_days", "low_keys_threshold", "default_checkout_days")
+SETTINGS_TEXT_FIELDS = ("receipt_header", "receipt_footer")
+
+
+@api_bp.get("/settings")
+@api_tenant_required
+def get_settings():
+    require_admin()
+    return jsonify(get_tenant_settings().to_dict())
+
+
+@api_bp.patch("/settings")
+@api_tenant_required
+def update_settings():
+    require_admin()
+    settings = get_tenant_settings()
+    body = get_json_body()
+
+    known = set(SETTINGS_BOOL_FIELDS) | set(SETTINGS_INT_FIELDS) | set(SETTINGS_TEXT_FIELDS)
+    unknown = set(body.keys()) - known
+    if unknown:
+        raise error(400, "unknown_fields", f"Unknown setting(s): {', '.join(sorted(unknown))}.")
+
+    for field in SETTINGS_BOOL_FIELDS:
+        if field in body:
+            value = clean_bool(body.get(field), field)
+            if value is None:
+                raise error(400, "invalid_field", f"'{field}' cannot be null.")
+            setattr(settings, field, value)
+    for field in SETTINGS_INT_FIELDS:
+        if field in body:
+            value = clean_int(body.get(field), field)
+            if value is None or value < 0:
+                raise error(400, "invalid_field", f"'{field}' must be a non-negative integer.")
+            setattr(settings, field, value)
+    for field in SETTINGS_TEXT_FIELDS:
+        if field in body:
+            setattr(settings, field, clean_str(body.get(field), field))
+
+    log_activity("settings_updated", user=g.api_user, target=settings,
+                 summary="Updated tenant settings via API",
+                 meta={"fields": sorted(set(body.keys()))}, commit=False)
+    tenant_commit()
+    return jsonify(settings.to_dict())
+
+
+# --- Activity logs ----------------------------------------------------------------
+
+@api_bp.get("/activity-logs")
+@api_tenant_required
+def list_activity_logs():
+    require_admin()
+    query = tenant_query(ActivityLog)
+
+    action = request.args.get("action")
+    if action:
+        query = query.filter(ActivityLog.action == action)
+
+    user_id = request.args.get("user_id", type=int)
+    if user_id:
+        query = query.filter(ActivityLog.user_id == user_id)
+
+    target_type = request.args.get("target_type")
+    if target_type:
+        query = query.filter(ActivityLog.target_type == target_type)
+
+    query = query.order_by(ActivityLog.created_at.desc())
+    rows, meta = paginate(query)
+    return jsonify({"activity_logs": [r.to_dict() for r in rows], "pagination": meta})
+
+
+# --- Stats -------------------------------------------------------------------------
+
+@api_bp.get("/stats")
+@api_tenant_required
+def stats():
+    """Dashboard-style summary: item counts, active checkouts, overdue."""
+    by_type_status = {}
+    for item_type, status, count in (
+        tenant_query(Item)
+        .with_entities(Item.type, Item.status, master_db.func.count(Item.id))
+        .group_by(Item.type, Item.status)
+        .all()
+    ):
+        by_type_status.setdefault(item_type, {})[status] = count
+
+    active_checkouts = tenant_query(ItemCheckout).filter_by(is_active=True).count()
+    overdue = tenant_query(ItemCheckout).filter(
+        ItemCheckout.is_active.is_(True),
+        ItemCheckout.expected_return_date.isnot(None),
+        ItemCheckout.expected_return_date < utc_now(),
+    ).count()
+
+    return jsonify({
+        "items": by_type_status,
+        "active_checkouts": active_checkouts,
+        "overdue_checkouts": overdue,
+    })
+
+
+# --- Accounts (app admin, root domain) ------------------------------------------------
+
+@api_bp.get("/accounts")
+@api_auth_required
+def list_accounts():
+    if (g.api_user.role or "").lower() != "app_admin":
+        raise error(403, "admin_required", "This endpoint requires an app admin token.")
+    accounts = Account.query.order_by(Account.company_name.asc()).all()
+    return jsonify({"accounts": [a.to_dict() for a in accounts]})

--- a/api/routes_audits.py
+++ b/api/routes_audits.py
@@ -1,0 +1,38 @@
+"""Audit sessions (read-only in the API — audits are conducted in the web UI)."""
+
+from flask import jsonify, request
+
+from api import api_bp
+from api.helpers import api_tenant_required, error, list_response, paginate
+from utilities.database import Audit
+from utilities.tenant_helpers import get_tenant_session, tenant_query
+
+
+@api_bp.get("/audits")
+@api_tenant_required
+def list_audits():
+    query = tenant_query(Audit)
+
+    status = request.args.get("status")
+    if status:
+        query = query.filter(Audit.status == status)
+
+    query = query.order_by(Audit.created_at.desc())
+    rows, meta = paginate(query)
+    return list_response("audits", rows, meta)
+
+
+@api_bp.get("/audits/<int:audit_id>")
+@api_tenant_required
+def get_audit(audit_id: int):
+    audit = get_tenant_session().get(Audit, audit_id)
+    if audit is None:
+        raise error(404, "not_found", f"Audit {audit_id} not found.")
+
+    payload = audit.to_dict()
+    payload["items"] = [ai.to_dict() for ai in audit.items]
+    payload["discrepancy_count"] = sum(
+        1 for ai in audit.items
+        if ai.discrepancy_type and ai.discrepancy_type != "none"
+    )
+    return jsonify(payload)

--- a/api/routes_checkouts.py
+++ b/api/routes_checkouts.py
@@ -1,0 +1,67 @@
+"""Checkout / assignment history (read-only — mutations happen via item actions)."""
+
+from flask import jsonify, request
+
+from api import api_bp
+from api.helpers import api_tenant_required, error, paginate
+from utilities.database import ItemCheckout, utc_now
+from utilities.tenant_helpers import get_tenant_session, tenant_query
+
+
+def _serialize(checkout: ItemCheckout) -> dict:
+    payload = checkout.to_dict()
+    if checkout.item:
+        payload["item"] = {
+            "id": checkout.item.id,
+            "custom_id": checkout.item.custom_id,
+            "type": checkout.item.type,
+            "label": checkout.item.label,
+        }
+    payload["contact_id"] = checkout.contact_id
+    return payload
+
+
+@api_bp.get("/checkouts")
+@api_tenant_required
+def list_checkouts():
+    query = tenant_query(ItemCheckout)
+
+    active = request.args.get("active")
+    if active is not None:
+        query = query.filter(ItemCheckout.is_active.is_(active.lower() in ("true", "1", "yes")))
+
+    item_id = request.args.get("item_id", type=int)
+    if item_id:
+        query = query.filter(ItemCheckout.item_id == item_id)
+
+    contact_id = request.args.get("contact_id", type=int)
+    if contact_id:
+        query = query.filter(ItemCheckout.contact_id == contact_id)
+
+    person = request.args.get("person")
+    if person:
+        query = query.filter(ItemCheckout.checked_out_to.ilike(f"%{person}%"))
+
+    if request.args.get("overdue", "").lower() in ("true", "1", "yes"):
+        query = query.filter(
+            ItemCheckout.is_active.is_(True),
+            ItemCheckout.expected_return_date.isnot(None),
+            ItemCheckout.expected_return_date < utc_now(),
+        )
+
+    query = query.order_by(ItemCheckout.checked_out_at.desc())
+
+    page_rows, meta = paginate(query)
+    return jsonify({
+        "checkouts": [_serialize(c) for c in page_rows],
+        "pagination": meta,
+    })
+
+
+@api_bp.get("/checkouts/<int:checkout_id>")
+@api_tenant_required
+def get_checkout(checkout_id: int):
+    checkout = get_tenant_session().get(ItemCheckout, checkout_id)
+    if checkout is None:
+        raise error(404, "not_found", f"Checkout {checkout_id} not found.")
+    return jsonify(_serialize(checkout))

--- a/api/routes_contacts.py
+++ b/api/routes_contacts.py
@@ -1,0 +1,118 @@
+"""Contacts CRUD."""
+
+from flask import g, jsonify, request
+
+from api import api_bp
+from api.helpers import (
+    api_tenant_required,
+    clean_str,
+    error,
+    get_json_body,
+    list_response,
+    paginate,
+    require_admin,
+)
+from utilities.database import db, Contact, ItemCheckout, log_activity
+from utilities.tenant_helpers import get_tenant_session, tenant_add, tenant_commit, tenant_query
+
+CONTACT_STR_FIELDS = ("contact_type", "name", "company", "email", "phone", "notes")
+
+
+def _get_contact_or_404(contact_id: int) -> Contact:
+    contact = get_tenant_session().get(Contact, contact_id)
+    if contact is None:
+        raise error(404, "not_found", f"Contact {contact_id} not found.")
+    return contact
+
+
+def _apply_fields(contact: Contact, body: dict):
+    for field in CONTACT_STR_FIELDS:
+        if field in body:
+            setattr(contact, field, clean_str(body.get(field), field, 255))
+    if not contact.name:
+        raise error(400, "invalid_field", "'name' is required.")
+    if not contact.contact_type:
+        contact.contact_type = "other"
+
+
+@api_bp.get("/contacts")
+@api_tenant_required
+def list_contacts():
+    query = tenant_query(Contact)
+
+    contact_type = request.args.get("type")
+    if contact_type:
+        query = query.filter(Contact.contact_type == contact_type)
+
+    q = request.args.get("q")
+    if q:
+        like = f"%{q}%"
+        query = query.filter(db.or_(
+            Contact.name.ilike(like),
+            Contact.company.ilike(like),
+            Contact.email.ilike(like),
+            Contact.phone.ilike(like),
+        ))
+
+    query = query.order_by(Contact.name.asc())
+    rows, meta = paginate(query)
+    return list_response("contacts", rows, meta)
+
+
+@api_bp.post("/contacts")
+@api_tenant_required
+def create_contact():
+    body = get_json_body()
+    contact = Contact()
+    _apply_fields(contact, body)
+    tenant_add(contact)
+    log_activity("contact_added", user=g.api_user, target=contact,
+                 summary=f"Added contact {contact.name} via API", commit=False)
+    tenant_commit()
+    return jsonify(contact.to_dict()), 201
+
+
+@api_bp.get("/contacts/<int:contact_id>")
+@api_tenant_required
+def get_contact(contact_id: int):
+    contact = _get_contact_or_404(contact_id)
+    payload = contact.to_dict()
+    payload["active_checkouts"] = [
+        c.to_dict() for c in tenant_query(ItemCheckout)
+        .filter_by(contact_id=contact.id, is_active=True)
+        .order_by(ItemCheckout.checked_out_at.desc())
+        .all()
+    ]
+    return jsonify(payload)
+
+
+@api_bp.patch("/contacts/<int:contact_id>")
+@api_tenant_required
+def update_contact(contact_id: int):
+    contact = _get_contact_or_404(contact_id)
+    body = get_json_body()
+    _apply_fields(contact, body)
+    log_activity("contact_updated", user=g.api_user, target=contact,
+                 summary=f"Updated contact {contact.name} via API",
+                 meta={"fields": sorted(set(body.keys()))}, commit=False)
+    tenant_commit()
+    return jsonify(contact.to_dict())
+
+
+@api_bp.delete("/contacts/<int:contact_id>")
+@api_tenant_required
+def delete_contact(contact_id: int):
+    require_admin()
+    contact = _get_contact_or_404(contact_id)
+
+    active = tenant_query(ItemCheckout).filter_by(contact_id=contact.id, is_active=True).count()
+    if active:
+        raise error(409, "contact_in_use",
+                    f"This contact has {active} active checkout(s). Check items in first.")
+
+    name, cid = contact.name, contact.id
+    get_tenant_session().delete(contact)
+    log_activity("contact_deleted", user=g.api_user, target_type="Contact", target_id=cid,
+                 summary=f"Deleted contact {name} via API", commit=False)
+    tenant_commit()
+    return jsonify({"deleted": True, "id": cid})

--- a/api/routes_items.py
+++ b/api/routes_items.py
@@ -1,0 +1,652 @@
+"""Inventory items: CRUD plus checkout / checkin / assign actions.
+
+The action endpoints mirror the web flows in inventory/views.py exactly —
+same status transitions, same validation rules, same activity-log actions —
+so records created via the API are indistinguishable from web activity.
+"""
+
+from flask import g, jsonify, request
+
+from api import api_bp
+from api.helpers import (
+    api_tenant_required,
+    clean_int,
+    clean_str,
+    error,
+    get_json_body,
+    list_response,
+    paginate,
+    parse_date,
+    require_admin,
+)
+from utilities.database import (
+    db,
+    Contact,
+    Item,
+    ItemCheckout,
+    Property,
+    PropertyUnit,
+    log_activity,
+    utc_now,
+)
+from utilities.tenant_helpers import (
+    get_tenant_session,
+    tenant_add,
+    tenant_commit,
+    tenant_query,
+)
+
+ITEM_TYPES = ("Lockbox", "Key", "Sign")
+
+# Fields writable via POST/PATCH, per type. Status and checkout counters are
+# managed exclusively by the action endpoints.
+COMMON_FIELDS = {"label", "location", "address", "assigned_to"}
+TYPE_FIELDS = {
+    "Lockbox": COMMON_FIELDS | {"code_current", "code_previous", "supra_id"},
+    "Key": COMMON_FIELDS | {"key_hook_number", "keycode", "total_copies", "checkout_purpose", "master_key_id"},
+    "Sign": COMMON_FIELDS | {"sign_subtype", "piece_type", "rider_text", "material", "condition"},
+}
+INT_FIELDS = {"total_copies", "master_key_id"}
+
+
+def _get_item_or_404(item_ref: str) -> Item:
+    """Look up an item by numeric id or by custom_id (e.g. 'KA042')."""
+    item = None
+    if item_ref.isdigit():
+        item = get_tenant_session().get(Item, int(item_ref))
+    if item is None:
+        item = tenant_query(Item).filter(
+            db.func.upper(Item.custom_id) == item_ref.upper()
+        ).first()
+    if item is None:
+        raise error(404, "not_found", f"Item '{item_ref}' not found.")
+    return item
+
+
+def _validate_contact_id(raw) -> int | None:
+    cid = clean_int(raw, "contact_id")
+    if cid is None:
+        return None
+    contact = get_tenant_session().get(Contact, cid)
+    if contact is None:
+        raise error(400, "invalid_field", f"Contact {cid} not found.")
+    return contact.id
+
+
+def _resolve_property_refs(body):
+    """Validate property_id / property_unit_id like the web assign forms do."""
+    property_obj = None
+    unit_obj = None
+    pid = clean_int(body.get("property_id"), "property_id")
+    uid = clean_int(body.get("property_unit_id"), "property_unit_id")
+    if pid is not None:
+        property_obj = get_tenant_session().get(Property, pid)
+        if property_obj is None:
+            raise error(400, "invalid_field", f"Property {pid} not found.")
+    if uid is not None:
+        unit_obj = get_tenant_session().get(PropertyUnit, uid)
+        if unit_obj is None:
+            raise error(400, "invalid_field", f"Property unit {uid} not found.")
+        if property_obj and unit_obj.property_id != property_obj.id:
+            raise error(400, "invalid_field", "Selected unit does not belong to the chosen property.")
+        if property_obj is None:
+            property_obj = unit_obj.property
+    return property_obj, unit_obj
+
+
+def _apply_writable_fields(item: Item, body: dict):
+    allowed = TYPE_FIELDS[item.type]
+    unknown = set(body.keys()) - allowed - {"type", "custom_id", "property_id", "property_unit_id"}
+    if unknown:
+        raise error(400, "unknown_fields",
+                    f"Unknown or read-only field(s) for a {item.type}: {', '.join(sorted(unknown))}.")
+
+    for field in allowed:
+        if field not in body:
+            continue
+        if field in INT_FIELDS:
+            value = clean_int(body.get(field), field)
+            if field == "total_copies" and value is not None and value < 0:
+                raise error(400, "invalid_field", "'total_copies' cannot be negative.")
+            if field == "master_key_id" and value is not None:
+                master = tenant_query(Item).filter_by(id=value, type="Key").first()
+                if master is None:
+                    raise error(400, "invalid_field", f"Master key {value} not found.")
+                if master.id == item.id:
+                    raise error(400, "invalid_field", "A key cannot be its own master key.")
+            setattr(item, field, value)
+        else:
+            setattr(item, field, clean_str(body.get(field), field, 255))
+
+    if "property_id" in body or "property_unit_id" in body:
+        property_obj, unit_obj = _resolve_property_refs(body)
+        if "property_id" in body:
+            item.property = property_obj
+        if "property_unit_id" in body:
+            item.property_unit = unit_obj
+
+
+# --- CRUD --------------------------------------------------------------------
+
+@api_bp.get("/items")
+@api_tenant_required
+def list_items():
+    query = tenant_query(Item)
+
+    item_type = request.args.get("type")
+    if item_type:
+        if item_type not in ITEM_TYPES:
+            raise error(400, "invalid_field", f"'type' must be one of: {', '.join(ITEM_TYPES)}.")
+        query = query.filter(Item.type == item_type)
+
+    status = request.args.get("status")
+    if status:
+        query = query.filter(Item.status == status)
+
+    property_id = request.args.get("property_id", type=int)
+    if property_id:
+        query = query.filter(Item.property_id == property_id)
+
+    assigned_to = request.args.get("assigned_to")
+    if assigned_to:
+        query = query.filter(Item.assigned_to.ilike(f"%{assigned_to}%"))
+
+    q = request.args.get("q")
+    if q:
+        like = f"%{q}%"
+        query = query.filter(db.or_(
+            Item.custom_id.ilike(like),
+            Item.label.ilike(like),
+            Item.address.ilike(like),
+            Item.location.ilike(like),
+        ))
+
+    query = query.order_by(Item.id.asc())
+    rows, meta = paginate(query)
+    return list_response("items", rows, meta)
+
+
+@api_bp.post("/items")
+@api_tenant_required
+def create_item():
+    body = get_json_body()
+
+    item_type = clean_str(body.get("type"), "type", 50)
+    if item_type not in ITEM_TYPES:
+        raise error(400, "invalid_field", f"'type' is required and must be one of: {', '.join(ITEM_TYPES)}.")
+
+    label = clean_str(body.get("label"), "label", 120)
+    if not label:
+        raise error(400, "invalid_field", "'label' is required.")
+
+    sign_subtype = clean_str(body.get("sign_subtype"), "sign_subtype", 20)
+    custom_id = clean_str(body.get("custom_id"), "custom_id", 20)
+    if custom_id:
+        existing = tenant_query(Item).filter(
+            db.func.upper(Item.custom_id) == custom_id.upper()
+        ).first()
+        if existing:
+            raise error(409, "duplicate_custom_id", f"Custom ID '{custom_id}' is already in use.")
+    else:
+        custom_id = Item.generate_custom_id(item_type, sign_subtype)
+
+    item = Item(type=item_type, label=label, custom_id=custom_id, status="available")
+    item.last_action = "added"
+    item.last_action_at = utc_now()
+    item.last_action_by_id = g.api_user.id
+    _apply_writable_fields(item, {k: v for k, v in body.items() if k not in ("type", "custom_id", "label")} | {"label": label})
+
+    tenant_add(item)
+    log_activity(
+        f"{item_type.lower()}_added",
+        user=g.api_user,
+        target=item,
+        summary=f"Added {item_type.lower()} {item.label} via API",
+        commit=False,
+    )
+    tenant_commit()
+    return jsonify(item.to_dict()), 201
+
+
+@api_bp.get("/items/<item_ref>")
+@api_tenant_required
+def get_item(item_ref: str):
+    item = _get_item_or_404(item_ref)
+    payload = item.to_dict()
+    payload["active_checkouts"] = [
+        c.to_dict() for c in tenant_query(ItemCheckout)
+        .filter_by(item_id=item.id, is_active=True)
+        .order_by(ItemCheckout.checked_out_at.desc())
+        .all()
+    ]
+    return jsonify(payload)
+
+
+@api_bp.patch("/items/<item_ref>")
+@api_tenant_required
+def update_item(item_ref: str):
+    item = _get_item_or_404(item_ref)
+    body = get_json_body()
+
+    if "type" in body and body["type"] != item.type:
+        raise error(400, "invalid_field", "An item's type cannot be changed.")
+    if "custom_id" in body:
+        new_custom = clean_str(body.get("custom_id"), "custom_id", 20)
+        if not new_custom:
+            raise error(400, "invalid_field", "'custom_id' cannot be blank.")
+        clash = tenant_query(Item).filter(
+            db.func.upper(Item.custom_id) == new_custom.upper(),
+            Item.id != item.id,
+        ).first()
+        if clash:
+            raise error(409, "duplicate_custom_id", f"Custom ID '{new_custom}' is already in use.")
+        item.custom_id = new_custom
+    if "label" in body:
+        label = clean_str(body.get("label"), "label", 120)
+        if not label:
+            raise error(400, "invalid_field", "'label' cannot be blank.")
+
+    _apply_writable_fields(item, body)
+    item.last_action_by_id = g.api_user.id
+
+    log_activity(
+        f"{item.type.lower()}_updated",
+        user=g.api_user,
+        target=item,
+        summary=f"Updated {item.type.lower()} {item.label} via API",
+        meta={"fields": sorted(set(body.keys()))},
+        commit=False,
+    )
+    tenant_commit()
+    return jsonify(item.to_dict())
+
+
+@api_bp.delete("/items/<item_ref>")
+@api_tenant_required
+def delete_item(item_ref: str):
+    require_admin()
+    item = _get_item_or_404(item_ref)
+
+    if item.status in ("checked_out", "assigned"):
+        raise error(409, "item_in_use",
+                    f"Item is currently {item.status}. Check it in before deleting.")
+    if item.type == "Sign" and item.sign_subtype == "Assembled Unit":
+        pieces = tenant_query(Item).filter_by(parent_sign_id=item.id).count()
+        if pieces:
+            raise error(409, "item_in_use",
+                        "Disassemble this sign before deleting — it still has attached pieces.")
+
+    label, item_type, item_id = item.label, item.type, item.id
+    session = get_tenant_session()
+
+    # Delete related records first and detach references — mirrors the web
+    # delete flows (existing tenant databases may lack CASCADE on these FKs).
+    from utilities.database import AuditItem
+    for checkout in tenant_query(ItemCheckout).filter_by(item_id=item_id).all():
+        session.delete(checkout)
+    for audit_item in tenant_query(AuditItem).filter_by(item_id=item_id).all():
+        session.delete(audit_item)
+    for child in tenant_query(Item).filter_by(master_key_id=item_id).all():
+        child.master_key_id = None
+    for piece in tenant_query(Item).filter_by(parent_sign_id=item_id).all():
+        piece.parent_sign_id = None
+        piece.status = "available"
+
+    session.delete(item)
+    log_activity(
+        f"{item_type.lower()}_deleted",
+        user=g.api_user,
+        target_type="Item",
+        target_id=item_id,
+        summary=f"Deleted {item_type.lower()} {label} via API",
+        commit=False,
+    )
+    tenant_commit()
+    return jsonify({"deleted": True, "id": item_id})
+
+
+# --- Actions ------------------------------------------------------------------
+
+@api_bp.post("/items/<item_ref>/checkout")
+@api_tenant_required
+def checkout_item(item_ref: str):
+    item = _get_item_or_404(item_ref)
+    body = get_json_body()
+    user = g.api_user
+
+    if item.type == "Key":
+        copies = clean_int(body.get("copies"), "copies") or 1
+        available = (item.total_copies or 0) - (item.copies_checked_out or 0)
+        if copies < 1 or copies > available:
+            raise error(409, "no_copies_available",
+                        f"Invalid number of copies. Available: {available}.")
+
+        purpose = clean_str(body.get("purpose"), "purpose", 255)
+        checked_out_to = clean_str(body.get("checked_out_to"), "checked_out_to", 255) or user.name
+        contact_id = _validate_contact_id(body.get("contact_id"))
+        expected_return = parse_date(body.get("expected_return_date"), "expected_return_date")
+
+        item.copies_checked_out = (item.copies_checked_out or 0) + copies
+        item.status = "checked_out"
+        item.checkout_purpose = purpose or item.checkout_purpose
+        item.expected_return_date = expected_return or item.expected_return_date
+        item.record_action("checked_out", user)
+
+        record = ItemCheckout(
+            item_id=item.id,
+            checked_out_to=checked_out_to,
+            contact_id=contact_id,
+            checked_out_by_id=user.id,
+            quantity=copies,
+            purpose=purpose,
+            expected_return_date=expected_return,
+            checked_out_at=utc_now(),
+            is_active=True,
+        )
+        tenant_add(record)
+        log_activity(
+            "key_checked_out",
+            user=user,
+            target=item,
+            summary=f"Checked out {copies} cop{'y' if copies == 1 else 'ies'} of key {item.label} to {checked_out_to}",
+            meta={"copies": copies, "checked_out_to": checked_out_to, "purpose": purpose, "via": "api"},
+            commit=False,
+        )
+        tenant_commit()
+        _safe_notify_checkout(record)
+        return jsonify({"item": item.to_dict(), "checkout": record.to_dict()}), 201
+
+    if item.type == "Lockbox":
+        code = clean_str(body.get("code"), "code", 20)
+        if not code:
+            raise error(400, "invalid_field", "'code' is required to check out a lockbox (rotates the stored code).")
+
+        item.code_previous = item.code_current
+        item.code_current = code
+        item.status = "checked_out"
+        item.record_action("checked_out", user)
+        assigned_to = clean_str(body.get("assigned_to"), "assigned_to", 120)
+        if assigned_to:
+            item.assigned_to = assigned_to
+        _apply_optional_location_address(item, body)
+
+        log_activity(
+            "lockbox_checked_out",
+            user=user,
+            target=item,
+            summary=f"Checked out lockbox {item.label}",
+            meta={"assigned_to": item.assigned_to, "location": item.location, "address": item.address, "via": "api"},
+            commit=False,
+        )
+        tenant_commit()
+        return jsonify({"item": item.to_dict()}), 200
+
+    # Sign
+    if item.parent_sign_id is not None:
+        raise error(409, "item_in_use", "Cannot check out a piece that's part of an assembled unit.")
+
+    item.status = "checked_out"
+    item.checkout_purpose = clean_str(body.get("purpose"), "purpose", 255)
+    assigned_to = clean_str(body.get("assigned_to"), "assigned_to", 120)
+    if assigned_to:
+        item.assigned_to = assigned_to
+    item.record_action("checked_out", user)
+    _apply_optional_location_address(item, body)
+
+    log_activity(
+        "sign_checked_out",
+        user=user,
+        target=item,
+        summary=f"Checked out sign {item.label}",
+        meta={"assigned_to": item.assigned_to, "location": item.location, "address": item.address, "via": "api"},
+        commit=False,
+    )
+    tenant_commit()
+    return jsonify({"item": item.to_dict()}), 200
+
+
+@api_bp.post("/items/<item_ref>/checkin")
+@api_tenant_required
+def checkin_item(item_ref: str):
+    item = _get_item_or_404(item_ref)
+    body = get_json_body()
+    user = g.api_user
+
+    if item.type == "Key":
+        checkout = None
+        checkout_id = clean_int(body.get("checkout_id"), "checkout_id")
+        if checkout_id is not None:
+            checkout = tenant_query(ItemCheckout).filter_by(
+                id=checkout_id, item_id=item.id, is_active=True
+            ).first()
+            if checkout is None:
+                raise error(404, "not_found", f"Active checkout {checkout_id} not found for this key.")
+            copies = checkout.quantity
+            checked_out_to = checkout.checked_out_to
+            checkout.is_active = False
+            checkout.checked_in_at = utc_now()
+            checkout.checked_in_by_id = user.id
+        else:
+            copies = clean_int(body.get("copies"), "copies")
+            if copies is not None:
+                checked_out = item.copies_checked_out or 0
+                if copies < 1 or copies > checked_out:
+                    raise error(409, "invalid_quantity",
+                                f"Invalid number of copies. Checked out: {checked_out}.")
+                checked_out_to = "Unknown"
+            elif item.status == "assigned" and item.assigned_to:
+                copies = item.copies_checked_out or item.total_copies or 1
+                checked_out_to = item.assigned_to
+            else:
+                raise error(400, "invalid_field",
+                            "Provide 'checkout_id' or 'copies' to check in this key.")
+
+        item.copies_checked_out = max(0, (item.copies_checked_out or 0) - copies)
+        if item.copies_checked_out == 0:
+            item.status = "available"
+            item.assigned_to = None
+            item.assignment_type = None
+            item.checkout_purpose = None
+            item.expected_return_date = None
+        item.record_action("checked_in", user)
+
+        log_activity(
+            "key_checked_in",
+            user=user,
+            target=item,
+            summary=f"Checked in {copies} cop{'y' if copies == 1 else 'ies'} of key {item.label} from {checked_out_to}",
+            meta={"copies": copies, "checked_out_to": checked_out_to,
+                  "checkout_id": checkout_id, "via": "api"},
+            commit=False,
+        )
+        tenant_commit()
+        if checkout is not None:
+            _safe_notify_checkin(checkout)
+        return jsonify({"item": item.to_dict()})
+
+    if item.type == "Lockbox":
+        code = clean_str(body.get("code"), "code", 20)
+        if not code:
+            raise error(400, "invalid_field", "'code' is required to check in a lockbox (rotates the stored code).")
+
+        item.code_previous = item.code_current
+        item.code_current = code
+        item.status = "available"
+        item.assigned_to = None
+        item.record_action("checked_in", user)
+        _apply_optional_location_address(item, body)
+
+        log_activity(
+            "lockbox_checked_in",
+            user=user,
+            target=item,
+            summary=f"Checked in lockbox {item.label}",
+            meta={"location": item.location, "address": item.address, "via": "api"},
+            commit=False,
+        )
+        tenant_commit()
+        return jsonify({"item": item.to_dict()})
+
+    # Sign
+    item.status = "available"
+    item.record_action("checked_in", user)
+    _apply_optional_location_address(item, body)
+
+    log_activity(
+        "sign_checked_in",
+        user=user,
+        target=item,
+        summary=f"Checked in sign {item.label}",
+        meta={"location": item.location, "address": item.address, "via": "api"},
+        commit=False,
+    )
+    tenant_commit()
+    return jsonify({"item": item.to_dict()})
+
+
+@api_bp.post("/items/<item_ref>/assign")
+@api_tenant_required
+def assign_item(item_ref: str):
+    item = _get_item_or_404(item_ref)
+    body = get_json_body()
+    user = g.api_user
+
+    assigned_to = clean_str(body.get("assigned_to"), "assigned_to", 255)
+    assignment_type = clean_str(body.get("assignment_type"), "assignment_type", 50)
+    expected_return = parse_date(body.get("expected_return_date"), "expected_return_date")
+    property_obj, unit_obj = _resolve_property_refs(body)
+
+    if assignment_type == "contractor" and expected_return is None:
+        raise error(400, "invalid_field", "Expected return date is required for contractor assignments.")
+
+    if assignment_type == "property":
+        if property_obj is None:
+            raise error(400, "invalid_field", "Select a property ('property_id') for a property assignment.")
+        if not assigned_to:
+            if unit_obj:
+                assigned_to = f"{property_obj.name} ({unit_obj.label})"
+            else:
+                assigned_to = property_obj.name
+    elif not assigned_to:
+        raise error(400, "invalid_field", "'assigned_to' is required.")
+
+    if item.type == "Key":
+        if not assignment_type:
+            raise error(400, "invalid_field", "'assignment_type' is required for keys (tenant|contractor|property).")
+        copies = clean_int(body.get("copies"), "copies") or 1
+        available = (item.total_copies or 0) - (item.copies_checked_out or 0)
+        if copies < 1 or copies > available:
+            raise error(409, "no_copies_available",
+                        f"Invalid number of copies. Available: {available}.")
+
+        if property_obj:
+            item.property = property_obj
+            if not item.address and property_obj.address_line1:
+                parts = [property_obj.address_line1, property_obj.city, property_obj.state, property_obj.postal_code]
+                item.address = ", ".join([p for p in parts if p])
+        if unit_obj:
+            item.property_unit = unit_obj
+
+        item.copies_checked_out = (item.copies_checked_out or 0) + copies
+        item.status = "assigned"
+        item.assigned_to = assigned_to
+        item.assignment_type = assignment_type
+        item.expected_return_date = expected_return or item.expected_return_date
+        item.record_action("assigned", user)
+
+        record = ItemCheckout(
+            item_id=item.id,
+            checked_out_to=assigned_to,
+            contact_id=_validate_contact_id(body.get("contact_id")),
+            checked_out_by_id=user.id,
+            quantity=copies,
+            assignment_type=assignment_type,
+            expected_return_date=expected_return,
+            address=item.address,
+            checked_out_at=utc_now(),
+            is_active=True,
+        )
+        tenant_add(record)
+        log_activity(
+            "key_assigned",
+            user=user,
+            target=item,
+            summary=f"Assigned {copies} cop{'y' if copies == 1 else 'ies'} of key {item.label} to {assigned_to}",
+            meta={"copies": copies, "assigned_to": assigned_to, "assignment_type": assignment_type, "via": "api"},
+            commit=False,
+        )
+        tenant_commit()
+        _safe_notify_checkout(record)
+        return jsonify({"item": item.to_dict(), "checkout": record.to_dict()}), 201
+
+    if item.type == "Lockbox":
+        if property_obj:
+            item.property = property_obj
+            address = clean_str(body.get("address"), "address", 255)
+            if not address:
+                parts = [property_obj.address_line1, property_obj.city, property_obj.state, property_obj.postal_code]
+                item.address = ", ".join([p for p in parts if p])
+        if unit_obj:
+            item.property_unit = unit_obj
+
+        item.assigned_to = assigned_to
+        item.assignment_type = assignment_type
+        item.expected_return_date = expected_return
+        item.status = "assigned"
+        item.record_action("assigned", user)
+        _apply_optional_location_address(item, body)
+
+        log_activity(
+            "lockbox_assigned",
+            user=user,
+            target=item,
+            summary=f"Assigned lockbox {item.label} to {assigned_to} ({assignment_type or 'unknown'})",
+            meta={"assigned_to": assigned_to, "assignment_type": assignment_type, "via": "api"},
+            commit=False,
+        )
+        tenant_commit()
+        return jsonify({"item": item.to_dict()})
+
+    # Sign
+    item.status = "assigned"
+    item.assigned_to = assigned_to
+    item.assignment_type = assignment_type
+    item.expected_return_date = expected_return
+    item.record_action("assigned", user)
+    _apply_optional_location_address(item, body)
+
+    log_activity(
+        "sign_assigned",
+        user=user,
+        target=item,
+        summary=f"Assigned sign {item.label} to {assigned_to}",
+        meta={"assigned_to": assigned_to, "assignment_type": assignment_type, "via": "api"},
+        commit=False,
+    )
+    tenant_commit()
+    return jsonify({"item": item.to_dict()})
+
+
+# --- Small shared bits ---------------------------------------------------------
+
+def _apply_optional_location_address(item: Item, body: dict):
+    if "location" in body:
+        item.location = clean_str(body.get("location"), "location", 120)
+    if "address" in body:
+        item.address = clean_str(body.get("address"), "address", 255)
+
+
+def _safe_notify_checkout(record: ItemCheckout):
+    try:
+        from utilities.email import notify_checkout
+        notify_checkout(record)
+    except Exception:
+        pass  # notifications are fire-and-forget; never fail the API call
+
+
+def _safe_notify_checkin(record: ItemCheckout):
+    try:
+        from utilities.email import notify_checkin
+        notify_checkin(record)
+    except Exception:
+        pass

--- a/api/routes_meta.py
+++ b/api/routes_meta.py
@@ -1,0 +1,55 @@
+"""API index, current-identity, and documentation endpoints."""
+
+from flask import g, jsonify, render_template
+
+from api import api_bp
+from api.helpers import api_auth_required
+from api.openapi import build_spec
+from config import APP_VERSION
+
+
+@api_bp.get("/")
+def index():
+    """Public API index — a quick orientation for anyone poking at the root."""
+    return jsonify({
+        "name": "KBM API",
+        "version": "v1",
+        "app_version": APP_VERSION,
+        "documentation": "/api/v1/docs",
+        "openapi": "/api/v1/openapi.json",
+        "authentication": (
+            "Create a token with POST /api/v1/auth/tokens {email, pin} on your "
+            "company subdomain, then send it as 'Authorization: Bearer <token>'."
+        ),
+    })
+
+
+@api_bp.get("/me")
+@api_auth_required
+def me():
+    """Identify the token's user — handy for smoke-testing credentials."""
+    user = g.api_user
+    token = g.api_token
+    return jsonify({
+        "user": user.to_dict(),
+        "token": token.to_dict(),
+    })
+
+
+@api_bp.get("/openapi.json")
+def openapi_spec():
+    return jsonify(build_spec())
+
+
+@api_bp.get("/docs")
+def docs():
+    import re
+    from markupsafe import Markup, escape
+
+    spec = build_spec()
+    # The OpenAPI description uses minimal markdown (**bold**, `code`).
+    # Render it as HTML for the docs page; JSON consumers get it verbatim.
+    text = str(escape(spec["info"]["description"]))
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    return render_template("api_docs.html", spec=spec, intro_html=Markup(text))

--- a/api/routes_properties.py
+++ b/api/routes_properties.py
@@ -1,0 +1,209 @@
+"""Properties and property units CRUD."""
+
+from flask import g, jsonify, request
+
+from api import api_bp
+from api.helpers import (
+    api_tenant_required,
+    clean_int,
+    clean_str,
+    error,
+    get_json_body,
+    list_response,
+    paginate,
+    require_admin,
+)
+from utilities.database import db, Item, Property, PropertyUnit, SmartLock, log_activity
+from utilities.tenant_helpers import get_tenant_session, tenant_add, tenant_commit, tenant_query
+
+PROPERTY_TYPES = ("single_family", "multi_family", "condo", "apartment", "commercial", "land", "other")
+PROPERTY_STR_FIELDS = ("name", "type", "address_line1", "address_line2", "city",
+                       "state", "postal_code", "country", "notes")
+UNIT_STR_FIELDS = ("label", "floor", "notes")
+
+
+def _get_property_or_404(property_id: int) -> Property:
+    prop = get_tenant_session().get(Property, property_id)
+    if prop is None:
+        raise error(404, "not_found", f"Property {property_id} not found.")
+    return prop
+
+
+def _get_unit_or_404(unit_id: int) -> PropertyUnit:
+    unit = get_tenant_session().get(PropertyUnit, unit_id)
+    if unit is None:
+        raise error(404, "not_found", f"Property unit {unit_id} not found.")
+    return unit
+
+
+def _apply_property_fields(prop: Property, body: dict, *, creating: bool):
+    for field in PROPERTY_STR_FIELDS:
+        if field in body:
+            setattr(prop, field, clean_str(body.get(field), field, 255))
+    for field in ("latitude", "longitude"):
+        if field in body:
+            value = body.get(field)
+            if value is not None and not isinstance(value, (int, float)):
+                raise error(400, "invalid_field", f"'{field}' must be a number.")
+            setattr(prop, field, value)
+
+    if not prop.name:
+        raise error(400, "invalid_field", "'name' is required.")
+    if not prop.address_line1:
+        raise error(400, "invalid_field", "'address_line1' is required.")
+    if creating and not prop.type:
+        prop.type = "single_family"
+
+
+@api_bp.get("/properties")
+@api_tenant_required
+def list_properties():
+    query = tenant_query(Property)
+    q = request.args.get("q")
+    if q:
+        like = f"%{q}%"
+        query = query.filter(db.or_(
+            Property.name.ilike(like),
+            Property.address_line1.ilike(like),
+            Property.city.ilike(like),
+        ))
+    query = query.order_by(Property.name.asc())
+    rows, meta = paginate(query)
+    return list_response("properties", rows, meta)
+
+
+@api_bp.post("/properties")
+@api_tenant_required
+def create_property():
+    body = get_json_body()
+    prop = Property()
+    _apply_property_fields(prop, body, creating=True)
+    tenant_add(prop)
+    log_activity("property_added", user=g.api_user, target=prop,
+                 summary=f"Added property {prop.name} via API", commit=False)
+    tenant_commit()
+    return jsonify(prop.to_dict()), 201
+
+
+@api_bp.get("/properties/<int:property_id>")
+@api_tenant_required
+def get_property(property_id: int):
+    prop = _get_property_or_404(property_id)
+    payload = prop.to_dict()
+    payload["units"] = [u.to_dict() for u in prop.units]
+    payload["item_count"] = tenant_query(Item).filter_by(property_id=prop.id).count()
+    payload["smart_lock_count"] = tenant_query(SmartLock).filter_by(property_id=prop.id).count()
+    return jsonify(payload)
+
+
+@api_bp.patch("/properties/<int:property_id>")
+@api_tenant_required
+def update_property(property_id: int):
+    prop = _get_property_or_404(property_id)
+    body = get_json_body()
+    _apply_property_fields(prop, body, creating=False)
+    log_activity("property_updated", user=g.api_user, target=prop,
+                 summary=f"Updated property {prop.name} via API",
+                 meta={"fields": sorted(set(body.keys()))}, commit=False)
+    tenant_commit()
+    return jsonify(prop.to_dict())
+
+
+@api_bp.delete("/properties/<int:property_id>")
+@api_tenant_required
+def delete_property(property_id: int):
+    require_admin()
+    prop = _get_property_or_404(property_id)
+
+    linked_items = tenant_query(Item).filter_by(property_id=prop.id).count()
+    if linked_items:
+        raise error(409, "property_in_use",
+                    f"{linked_items} item(s) are linked to this property. Unlink them first.")
+
+    name, pid = prop.name, prop.id
+    get_tenant_session().delete(prop)
+    log_activity("property_deleted", user=g.api_user, target_type="Property", target_id=pid,
+                 summary=f"Deleted property {name} via API", commit=False)
+    tenant_commit()
+    return jsonify({"deleted": True, "id": pid})
+
+
+# --- Units --------------------------------------------------------------------
+
+@api_bp.get("/properties/<int:property_id>/units")
+@api_tenant_required
+def list_units(property_id: int):
+    prop = _get_property_or_404(property_id)
+    return jsonify({"units": [u.to_dict() for u in prop.units]})
+
+
+@api_bp.post("/properties/<int:property_id>/units")
+@api_tenant_required
+def create_unit(property_id: int):
+    prop = _get_property_or_404(property_id)
+    body = get_json_body()
+
+    unit = PropertyUnit(property_id=prop.id)
+    _apply_unit_fields(unit, body)
+    if not unit.label:
+        raise error(400, "invalid_field", "'label' is required.")
+
+    tenant_add(unit)
+    log_activity("property_unit_added", user=g.api_user, target=unit,
+                 summary=f"Added unit {unit.label} to property {prop.name} via API", commit=False)
+    tenant_commit()
+    return jsonify(unit.to_dict()), 201
+
+
+@api_bp.get("/units/<int:unit_id>")
+@api_tenant_required
+def get_unit(unit_id: int):
+    return jsonify(_get_unit_or_404(unit_id).to_dict())
+
+
+@api_bp.patch("/units/<int:unit_id>")
+@api_tenant_required
+def update_unit(unit_id: int):
+    unit = _get_unit_or_404(unit_id)
+    body = get_json_body()
+    _apply_unit_fields(unit, body)
+    if not unit.label:
+        raise error(400, "invalid_field", "'label' cannot be blank.")
+    log_activity("property_unit_updated", user=g.api_user, target=unit,
+                 summary=f"Updated unit {unit.label} via API", commit=False)
+    tenant_commit()
+    return jsonify(unit.to_dict())
+
+
+@api_bp.delete("/units/<int:unit_id>")
+@api_tenant_required
+def delete_unit(unit_id: int):
+    require_admin()
+    unit = _get_unit_or_404(unit_id)
+
+    linked_items = tenant_query(Item).filter_by(property_unit_id=unit.id).count()
+    if linked_items:
+        raise error(409, "unit_in_use",
+                    f"{linked_items} item(s) are linked to this unit. Unlink them first.")
+
+    label, uid = unit.label, unit.id
+    get_tenant_session().delete(unit)
+    log_activity("property_unit_deleted", user=g.api_user, target_type="PropertyUnit", target_id=uid,
+                 summary=f"Deleted unit {label} via API", commit=False)
+    tenant_commit()
+    return jsonify({"deleted": True, "id": uid})
+
+
+def _apply_unit_fields(unit: PropertyUnit, body: dict):
+    for field in UNIT_STR_FIELDS:
+        if field in body:
+            setattr(unit, field, clean_str(body.get(field), field, 255))
+    if "bedrooms" in body:
+        unit.bedrooms = clean_int(body.get("bedrooms"), "bedrooms")
+    if "square_feet" in body:
+        unit.square_feet = clean_int(body.get("square_feet"), "square_feet")
+    if "bathrooms" in body:
+        value = body.get("bathrooms")
+        if value is not None and not isinstance(value, (int, float)):
+            raise error(400, "invalid_field", "'bathrooms' must be a number.")
+        unit.bathrooms = value

--- a/api/routes_smartlocks.py
+++ b/api/routes_smartlocks.py
@@ -1,0 +1,125 @@
+"""Smart locks CRUD (image uploads stay web-only)."""
+
+from flask import g, jsonify, request
+
+from api import api_bp
+from api.helpers import (
+    api_tenant_required,
+    clean_int,
+    clean_str,
+    error,
+    get_json_body,
+    list_response,
+    paginate,
+    require_admin,
+)
+from utilities.database import db, Property, PropertyUnit, SmartLock, log_activity
+from utilities.tenant_helpers import get_tenant_session, tenant_add, tenant_commit, tenant_query
+
+LOCK_STR_FIELDS = ("label", "provider", "code", "backup_code", "instructions", "notes",
+                   "model_number", "serial_number", "pairing_code", "qr_code_data")
+
+
+def _get_lock_or_404(lock_id: int) -> SmartLock:
+    lock = get_tenant_session().get(SmartLock, lock_id)
+    if lock is None:
+        raise error(404, "not_found", f"Smart lock {lock_id} not found.")
+    return lock
+
+
+def _apply_fields(lock: SmartLock, body: dict):
+    for field in LOCK_STR_FIELDS:
+        if field in body:
+            max_len = None if field in ("instructions", "notes", "qr_code_data") else 255
+            setattr(lock, field, clean_str(body.get(field), field, max_len))
+
+    if "property_id" in body:
+        pid = clean_int(body.get("property_id"), "property_id")
+        if pid is not None and get_tenant_session().get(Property, pid) is None:
+            raise error(400, "invalid_field", f"Property {pid} not found.")
+        lock.property_id = pid
+    if "property_unit_id" in body:
+        uid = clean_int(body.get("property_unit_id"), "property_unit_id")
+        if uid is not None:
+            unit = get_tenant_session().get(PropertyUnit, uid)
+            if unit is None:
+                raise error(400, "invalid_field", f"Property unit {uid} not found.")
+            if lock.property_id and unit.property_id != lock.property_id:
+                raise error(400, "invalid_field", "Selected unit does not belong to the chosen property.")
+        lock.property_unit_id = uid
+
+    if not lock.label:
+        raise error(400, "invalid_field", "'label' is required.")
+    if not lock.code:
+        raise error(400, "invalid_field", "'code' is required.")
+
+
+@api_bp.get("/smart-locks")
+@api_tenant_required
+def list_smart_locks():
+    query = tenant_query(SmartLock)
+
+    property_id = request.args.get("property_id", type=int)
+    if property_id:
+        query = query.filter(SmartLock.property_id == property_id)
+
+    q = request.args.get("q")
+    if q:
+        like = f"%{q}%"
+        query = query.filter(db.or_(
+            SmartLock.label.ilike(like),
+            SmartLock.provider.ilike(like),
+            SmartLock.model_number.ilike(like),
+        ))
+
+    query = query.order_by(SmartLock.label.asc())
+    rows, meta = paginate(query)
+    return list_response("smart_locks", rows, meta)
+
+
+@api_bp.post("/smart-locks")
+@api_tenant_required
+def create_smart_lock():
+    body = get_json_body()
+    lock = SmartLock()
+    _apply_fields(lock, body)
+    tenant_add(lock)
+    log_activity("smart_lock_added", user=g.api_user, target=lock,
+                 summary=f"Added smart lock {lock.label} via API", commit=False)
+    tenant_commit()
+    return jsonify(lock.to_dict()), 201
+
+
+@api_bp.get("/smart-locks/<int:lock_id>")
+@api_tenant_required
+def get_smart_lock(lock_id: int):
+    lock = _get_lock_or_404(lock_id)
+    payload = lock.to_dict()
+    payload["images"] = [img.to_dict() for img in lock.images]
+    return jsonify(payload)
+
+
+@api_bp.patch("/smart-locks/<int:lock_id>")
+@api_tenant_required
+def update_smart_lock(lock_id: int):
+    lock = _get_lock_or_404(lock_id)
+    body = get_json_body()
+    _apply_fields(lock, body)
+    log_activity("smart_lock_updated", user=g.api_user, target=lock,
+                 summary=f"Updated smart lock {lock.label} via API",
+                 meta={"fields": sorted(set(body.keys()))}, commit=False)
+    tenant_commit()
+    return jsonify(lock.to_dict())
+
+
+@api_bp.delete("/smart-locks/<int:lock_id>")
+@api_tenant_required
+def delete_smart_lock(lock_id: int):
+    require_admin()
+    lock = _get_lock_or_404(lock_id)
+    label, lid = lock.label, lock.id
+    get_tenant_session().delete(lock)
+    log_activity("smart_lock_deleted", user=g.api_user, target_type="SmartLock", target_id=lid,
+                 summary=f"Deleted smart lock {label} via API", commit=False)
+    tenant_commit()
+    return jsonify({"deleted": True, "id": lid})

--- a/api/routes_tokens.py
+++ b/api/routes_tokens.py
@@ -1,0 +1,129 @@
+"""API token lifecycle: create (email+PIN login), list, revoke.
+
+Token creation is the only API endpoint that authenticates with credentials
+instead of a Bearer token, so it is rate-limited like the web login.
+"""
+
+from datetime import timedelta
+
+from flask import g, jsonify
+
+from api import api_bp
+from api.helpers import (
+    api_auth_required,
+    clean_int,
+    clean_str,
+    error,
+    get_json_body,
+)
+from utilities.database import utc_now
+from utilities.extensions import limiter
+from utilities.master_database import master_db, ApiToken, MasterUser
+from utilities.tenant_manager import tenant_manager
+
+MAX_TOKENS_PER_USER = 25
+
+
+@api_bp.post("/auth/tokens")
+@limiter.limit("10 per minute; 30 per hour")
+def create_token():
+    """Exchange email + PIN for a long-lived API token.
+
+    Must be called on the company subdomain for tenant users. App admins
+    call it on the root domain and get a cross-tenant token.
+    """
+    body = get_json_body()
+    email = clean_str(body.get("email"), "email", 255)
+    pin = body.get("pin")
+    pin = str(pin).strip() if pin is not None else ""
+    name = clean_str(body.get("name"), "name", 120) or "API Token"
+    expires_in_days = clean_int(body.get("expires_in_days"), "expires_in_days")
+
+    if not email or not pin:
+        raise error(400, "missing_credentials", "Both 'email' and 'pin' are required.")
+    if expires_in_days is not None and expires_in_days < 1:
+        raise error(400, "invalid_field", "'expires_in_days' must be a positive integer.")
+
+    tenant = tenant_manager.get_current_tenant()
+    if tenant is not None:
+        user = MasterUser.query.filter(
+            master_db.func.lower(MasterUser.email) == email.lower(),
+            MasterUser.account_id == tenant.id,
+            MasterUser.is_active.is_(True),
+        ).first()
+    else:
+        # Root domain: only app admins may mint tokens here.
+        user = MasterUser.query.filter(
+            master_db.func.lower(MasterUser.email) == email.lower(),
+            MasterUser.role == "app_admin",
+            MasterUser.is_active.is_(True),
+        ).first()
+
+    if user is None or not user.check_pin(pin):
+        raise error(401, "invalid_credentials", "Email or PIN is incorrect.")
+
+    active_count = ApiToken.query.filter_by(user_id=user.id, revoked_at=None).count()
+    if active_count >= MAX_TOKENS_PER_USER:
+        raise error(409, "token_limit",
+                    f"You already have {active_count} active tokens. Revoke one before creating another.")
+
+    raw, prefix, token_hash = ApiToken.generate()
+    token = ApiToken(
+        account_id=user.account_id,
+        user_id=user.id,
+        name=name,
+        token_prefix=prefix,
+        token_hash=token_hash,
+        expires_at=(utc_now() + timedelta(days=expires_in_days)) if expires_in_days else None,
+    )
+    master_db.session.add(token)
+    master_db.session.commit()
+
+    payload = token.to_dict()
+    payload["token"] = raw  # shown exactly once
+    return jsonify(payload), 201
+
+
+@api_bp.get("/auth/tokens")
+@api_auth_required
+def list_tokens():
+    """List your own tokens. Admins see every token in the account."""
+    user = g.api_user
+    role = (user.role or "").lower()
+
+    query = ApiToken.query
+    if role == "app_admin":
+        query = query.filter(ApiToken.account_id.is_(None))
+    elif role in ("admin", "owner"):
+        query = query.filter(ApiToken.account_id == user.account_id)
+    else:
+        query = query.filter(ApiToken.user_id == user.id)
+
+    tokens = query.order_by(ApiToken.created_at.desc()).all()
+    return jsonify({"tokens": [t.to_dict() for t in tokens]})
+
+
+@api_bp.delete("/auth/tokens/<int:token_id>")
+@api_auth_required
+def revoke_token(token_id: int):
+    """Revoke a token. Users can revoke their own; admins any in the account."""
+    user = g.api_user
+    role = (user.role or "").lower()
+
+    token = master_db.session.get(ApiToken, token_id)
+    if token is None:
+        raise error(404, "not_found", "Token not found.")
+
+    allowed = token.user_id == user.id
+    if role == "app_admin":
+        allowed = True
+    elif role in ("admin", "owner") and token.account_id == user.account_id:
+        allowed = True
+    if not allowed:
+        raise error(403, "forbidden", "You cannot revoke this token.")
+
+    if token.revoked_at is None:
+        token.revoked_at = utc_now()
+        master_db.session.commit()
+
+    return jsonify({"revoked": True, "id": token.id})

--- a/app_multitenant.py
+++ b/app_multitenant.py
@@ -106,6 +106,16 @@ def create_app():
             master_db.create_all()
             print("Master database schema created")
 
+    # 6b) Ensure the api_tokens table exists (added in 2.2.0). checkfirst
+    # makes this a no-op on every boot after the first — safe for existing
+    # deployments that never run AUTO_CREATE_SCHEMA.
+    try:
+        from utilities.master_database import ApiToken
+        with app.app_context():
+            ApiToken.__table__.create(master_db.engine, checkfirst=True)
+    except Exception as e:
+        print(f"WARNING: could not ensure api_tokens table: {e}")
+
     # 6a) Apply pending tenant DB schema upgrades. Idempotent: each upgrade
     # checks whether its column/table is already present and only acts if
     # missing. Safe to run on every boot. See utilities/tenant_schema.py.
@@ -137,6 +147,11 @@ def create_app():
     app.register_blueprint(search_bp)
     app.register_blueprint(settings_bp, url_prefix="/settings")
     app.register_blueprint(help_bp, url_prefix="/help")
+
+    # REST API v1. Token-authenticated (Bearer), stateless — CSRF exemption
+    # happens below once csrf is initialized.
+    from api import api_bp
+    app.register_blueprint(api_bp, url_prefix="/api/v1")
 
     # 8) Debug helpers (DISABLED FOR SECURITY)
     # These routes are disabled for production security
@@ -261,6 +276,10 @@ def create_app():
     # protection — it just removes the redundant clock.
     app.config.setdefault("WTF_CSRF_TIME_LIMIT", None)
     csrf.init_app(app)
+    # The API authenticates every request with a Bearer token, so CSRF
+    # protection (a browser-session concern) doesn't apply.
+    from api import api_bp as _api_bp
+    csrf.exempt(_api_bp)
 
     # 10b) Rate Limiting
     # Always initialized so the @limiter.limit(...) decorators on login and
@@ -272,8 +291,17 @@ def create_app():
     limiter.init_app(app)
 
     # 11) Error handlers
+    def _wants_json(error=None):
+        # API clients get JSON errors, browsers get the HTML error pages.
+        return request.path.startswith("/api/")
+
+    def _json_error(status: int, code: str, message: str):
+        return {"error": {"code": code, "message": message}}, status
+
     @app.errorhandler(404)
     def handle_404(error):
+        if _wants_json():
+            return _json_error(404, "not_found", getattr(error, "description", None) or "Resource not found.")
         # If app admin is on root domain and hits 404, redirect to dashboard
         if current_user.is_authenticated and getattr(current_user, 'role', '') == 'app_admin' and g.get('is_root_domain', False):
             return redirect(url_for('app_admin.dashboard'))
@@ -281,14 +309,26 @@ def create_app():
 
     @app.errorhandler(403)
     def handle_403(error):
+        if _wants_json():
+            return _json_error(403, "forbidden", getattr(error, "description", None) or "Forbidden.")
         return render_template("403.html", error=error), 403
+
+    @app.errorhandler(405)
+    def handle_405(error):
+        if _wants_json():
+            return _json_error(405, "method_not_allowed", "Method not allowed for this endpoint.")
+        return render_template("404.html", error=error), 405
 
     @app.errorhandler(500)
     def handle_500(error):
+        if _wants_json():
+            return _json_error(500, "internal_error", "Internal server error.")
         return render_template("500.html", error=error), 500
 
     @app.errorhandler(429)
     def handle_429(error):
+        if _wants_json():
+            return _json_error(429, "rate_limited", "Too many requests. Slow down and retry shortly.")
         # Rate limit hit — currently only login and signup are limited, so a
         # flash + bounce back to the form is friendlier than a bare error page.
         from flask import request as _req, flash as _flash

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ if env_file:
     load_dotenv(env_file)
 
 # Application version — keep in sync with CHANGELOG.md.
-APP_VERSION = "2.1.0"
+APP_VERSION = "2.2.0"
 
 
 class Config:

--- a/helpcenter/views.py
+++ b/helpcenter/views.py
@@ -45,6 +45,8 @@ HELP_TOPICS = OrderedDict([
                      "summary": "Add users, set PINs, understand permissions, review activity."}),
     ("settings", {"title": "Settings", "icon": "⚙️",
                   "summary": "Email notifications, thresholds, and receipt text."}),
+    ("api", {"title": "API & Integrations", "icon": "🔌",
+             "summary": "Connect other apps to KBM with the REST API."}),
 ])
 
 

--- a/templates/api_docs.html
+++ b/templates/api_docs.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KBM API Reference</title>
+<style>
+  :root {
+    --bg: #f7f8fa; --card: #ffffff; --text: #1e2430; --muted: #61708b;
+    --border: #e3e7ee; --accent: #2563eb;
+    --get: #2563eb; --post: #16a34a; --patch: #d97706; --delete: #dc2626;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+         background: var(--bg); color: var(--text); line-height: 1.55; }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 32px 20px 80px; }
+  h1 { margin: 0 0 4px; font-size: 1.7rem; }
+  .subtitle { color: var(--muted); margin-bottom: 24px; }
+  .intro { background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+           padding: 18px 22px; margin-bottom: 28px; white-space: pre-wrap; }
+  .intro code, .op code { background: #eef1f6; padding: 1px 5px; border-radius: 4px; font-size: .9em; }
+  h2.tag { margin: 34px 0 10px; font-size: 1.2rem; border-bottom: 2px solid var(--border); padding-bottom: 6px; }
+  .op { background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+        margin-bottom: 10px; overflow: hidden; }
+  .op-header { display: flex; align-items: center; gap: 12px; padding: 10px 14px; cursor: pointer; }
+  .op-header:hover { background: #fafbfd; }
+  .method { font-weight: 700; font-size: .75rem; padding: 3px 9px; border-radius: 5px;
+            color: #fff; min-width: 56px; text-align: center; letter-spacing: .5px; }
+  .m-get { background: var(--get); } .m-post { background: var(--post); }
+  .m-patch { background: var(--patch); } .m-delete { background: var(--delete); }
+  .path { font-family: ui-monospace, "Cascadia Code", Consolas, monospace; font-size: .9rem; }
+  .summary { color: var(--muted); font-size: .88rem; margin-left: auto; text-align: right; }
+  .op-body { display: none; padding: 4px 16px 14px; border-top: 1px solid var(--border); font-size: .9rem; }
+  .op.open .op-body { display: block; }
+  .op-body h4 { margin: 12px 0 6px; font-size: .82rem; text-transform: uppercase;
+                letter-spacing: .6px; color: var(--muted); }
+  table { border-collapse: collapse; width: 100%; }
+  td, th { text-align: left; padding: 4px 10px 4px 0; vertical-align: top; }
+  th { color: var(--muted); font-size: .78rem; text-transform: uppercase; letter-spacing: .5px; }
+  .name { font-family: ui-monospace, Consolas, monospace; }
+  .badge { color: var(--muted); font-size: .8rem; }
+  .req { color: var(--delete); font-size: .78rem; font-weight: 600; }
+  .desc { margin: 8px 0 0; }
+  footer { margin-top: 40px; color: var(--muted); font-size: .85rem; }
+  a { color: var(--accent); }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #12151c; --card: #1a1f2a; --text: #e6eaf2; --muted: #94a3b8; --border: #2a3242; }
+    .op-header:hover { background: #1e2431; }
+    .intro code, .op code { background: #252d3d; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>{{ spec.info.title }} <span class="badge">v{{ spec.info.version }}</span></h1>
+  <div class="subtitle">Interactive reference &middot; <a href="openapi.json">openapi.json</a></div>
+  <div class="intro">{{ intro_html or spec.info.description }}</div>
+
+  {% for tag in spec.tags %}
+    <h2 class="tag">{{ tag.name }}</h2>
+    {% for path, methods in spec.paths.items() %}
+      {% for method, op in methods.items() %}
+        {% if op.tags and op.tags[0] == tag.name %}
+        <div class="op">
+          <div class="op-header" onclick="this.parentElement.classList.toggle('open')">
+            <span class="method m-{{ method }}">{{ method | upper }}</span>
+            <span class="path">{{ path }}</span>
+            <span class="summary">{{ op.summary }}</span>
+          </div>
+          <div class="op-body">
+            {% if op.description %}<p class="desc">{{ op.description }}</p>{% endif %}
+            {% if not op.security %}<p class="badge">No authentication required{% if 'tokens' in path and method == 'post' %} (credentials in body){% endif %}.</p>{% endif %}
+            {% if op.parameters %}
+              <h4>Parameters</h4>
+              <table>
+                <tr><th>Name</th><th>In</th><th>Type</th><th></th></tr>
+                {% for p in op.parameters %}
+                <tr>
+                  <td class="name">{{ p.name }}</td>
+                  <td class="badge">{{ p['in'] }}</td>
+                  <td class="badge">{{ p.schema.type }}{% if p.schema.enum %} ({{ p.schema.enum | join(' | ') }}){% endif %}</td>
+                  <td class="badge">{% if p.required %}<span class="req">required</span> {% endif %}{{ p.description or '' }}</td>
+                </tr>
+                {% endfor %}
+              </table>
+            {% endif %}
+            {% if op.requestBody %}
+              {% set schema = op.requestBody.content['application/json'].schema %}
+              <h4>Body (application/json)</h4>
+              <table>
+                <tr><th>Field</th><th>Type</th><th></th></tr>
+                {% for fname, fschema in schema.properties.items() %}
+                <tr>
+                  <td class="name">{{ fname }}</td>
+                  <td class="badge">{{ fschema.type }}{% if fschema.enum %} ({{ fschema.enum | join(' | ') }}){% endif %}</td>
+                  <td class="badge">
+                    {% if schema.required and fname in schema.required %}<span class="req">required</span>{% endif %}
+                    {{ fschema.description or '' }}
+                  </td>
+                </tr>
+                {% endfor %}
+              </table>
+            {% endif %}
+            <h4>Responses</h4>
+            <table>
+              {% for status, resp in op.responses.items() %}
+              <tr><td class="name">{{ status }}</td><td class="badge">{{ resp.description }}</td></tr>
+              {% endfor %}
+            </table>
+          </div>
+        </div>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  {% endfor %}
+
+  <footer>KBM API v{{ spec.info.version }} &middot; errors follow
+    <code>{"error": {"code", "message"}}</code></footer>
+</div>
+</body>
+</html>

--- a/templates/help/api.html
+++ b/templates/help/api.html
@@ -1,0 +1,59 @@
+{% extends "help/_topic.html" %}
+{% block help_content %}
+<h2>What the API is for</h2>
+<p>KBM has a full REST API so other software — spreadsheets, automation tools
+like Zapier or Make, your CRM, or custom scripts — can read and update your
+data. Anything you can do in the app (create items, check keys in and out,
+manage properties and contacts) can be done through the API.</p>
+
+<h2>Where to find the technical docs</h2>
+<ul>
+  <li><strong>Interactive reference</strong> — <a href="/api/v1/docs" target="_blank">/api/v1/docs</a>:
+      every endpoint with parameters, fields, and responses.</li>
+  <li><strong>OpenAPI spec</strong> — <code>/api/v1/openapi.json</code>: import into
+      Postman, Insomnia, or a code generator.</li>
+  <li><strong>Integration guide</strong> — <code>API_DOCUMENTATION.md</code> in the
+      project repository: walkthroughs and copy-paste examples.</li>
+</ul>
+
+<h2>Getting an API token</h2>
+<ol>
+  <li>Send a <code>POST</code> request to <code>/api/v1/auth/tokens</code> on your
+      company's address with your login <strong>email</strong> and <strong>PIN</strong>.</li>
+  <li>Copy the returned <code>token</code> — it is shown <strong>only once</strong>.
+      Store it somewhere safe, like a password manager.</li>
+  <li>Send it with every request as a header:
+      <code>Authorization: Bearer kbm_…</code></li>
+</ol>
+
+<div class="help-callout">
+  <strong>Permissions follow your role.</strong> A token can do exactly what the
+  user who created it can do. Deletes, user management, and settings need an
+  admin or owner token. Deactivating a user immediately disables their tokens.
+</div>
+
+<h2>Managing tokens</h2>
+<ul>
+  <li><strong>List</strong> — <code>GET /api/v1/auth/tokens</code> (admins see every
+      token in the account, including who created it and when it was last used).</li>
+  <li><strong>Revoke</strong> — <code>DELETE /api/v1/auth/tokens/&lt;id&gt;</code>.
+      Takes effect immediately.</li>
+  <li><strong>Expiry</strong> — pass <code>expires_in_days</code> when creating a token
+      to make it expire automatically.</li>
+</ul>
+
+<h2>Good to know</h2>
+<ul>
+  <li>Every change made through the API shows up in <strong>Activity Logs</strong>,
+      attributed to the token's user — same audit trail as the web app.</li>
+  <li>Key checkouts through the API send the same <strong>email notifications</strong>
+      you've configured in Settings.</li>
+  <li>Treat tokens like passwords: one token per integration, revoke anything
+      you no longer use.</li>
+</ul>
+
+<div class="help-callout tip">
+  <strong>Tip:</strong> test your token with <code>GET /api/v1/me</code> — it returns
+  the user and token the API sees, which makes setup problems obvious.
+</div>
+{% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,405 @@
+"""REST API v1 tests.
+
+Exercises the token lifecycle and every resource family end-to-end through
+the real app factory, on the tenant subdomain, exactly like a real client.
+"""
+import pytest
+
+TENANT_HOST = "acme.localhost"
+ROOT_HOST = "localhost"
+ADMIN_EMAIL = "admin@acme.test"
+ADMIN_PIN = "9999"
+
+
+@pytest.fixture(scope="module")
+def api(app):
+    """Anonymous client + helper that talks to the tenant subdomain."""
+    return app.test_client()
+
+
+@pytest.fixture(scope="module")
+def token(api):
+    """A real admin API token created through the public endpoint."""
+    resp = api.post(
+        "/api/v1/auth/tokens",
+        json={"email": ADMIN_EMAIL, "pin": ADMIN_PIN, "name": "pytest"},
+        headers={"Host": TENANT_HOST},
+    )
+    assert resp.status_code == 201, resp.get_json()
+    body = resp.get_json()
+    assert body["token"].startswith("kbm_")
+    return body["token"]
+
+
+@pytest.fixture(scope="module")
+def auth(token):
+    return {"Host": TENANT_HOST, "Authorization": f"Bearer {token}"}
+
+
+# --- Auth / tokens -------------------------------------------------------------
+
+def test_index_is_public(api):
+    resp = api.get("/api/v1/", headers={"Host": TENANT_HOST})
+    assert resp.status_code == 200
+    assert resp.get_json()["name"] == "KBM API"
+
+
+def test_openapi_and_docs(api):
+    resp = api.get("/api/v1/openapi.json", headers={"Host": TENANT_HOST})
+    assert resp.status_code == 200
+    assert resp.get_json()["openapi"].startswith("3.0")
+    resp = api.get("/api/v1/docs", headers={"Host": TENANT_HOST})
+    assert resp.status_code == 200
+    assert b"KBM API" in resp.data
+
+
+def test_token_rejects_bad_credentials(api):
+    resp = api.post(
+        "/api/v1/auth/tokens",
+        json={"email": ADMIN_EMAIL, "pin": "wrong"},
+        headers={"Host": TENANT_HOST},
+    )
+    assert resp.status_code == 401
+    assert resp.get_json()["error"]["code"] == "invalid_credentials"
+
+
+def test_missing_token_is_401(api):
+    resp = api.get("/api/v1/items", headers={"Host": TENANT_HOST})
+    assert resp.status_code == 401
+    assert resp.get_json()["error"]["code"] == "missing_token"
+
+
+def test_garbage_token_is_401(api):
+    resp = api.get(
+        "/api/v1/items",
+        headers={"Host": TENANT_HOST, "Authorization": "Bearer kbm_deadbeef_nope"},
+    )
+    assert resp.status_code == 401
+
+
+def test_me(api, auth):
+    resp = api.get("/api/v1/me", headers=auth)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["user"]["email"] == ADMIN_EMAIL
+    assert body["token"]["name"] == "pytest"
+
+
+def test_tenant_endpoint_requires_subdomain(api, token):
+    resp = api.get(
+        "/api/v1/items",
+        headers={"Host": ROOT_HOST, "Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+    assert resp.get_json()["error"]["code"] == "tenant_required"
+
+
+def test_token_list_and_revoke(api, auth):
+    # Mint a disposable token and revoke it.
+    resp = api.post(
+        "/api/v1/auth/tokens",
+        json={"email": ADMIN_EMAIL, "pin": ADMIN_PIN, "name": "disposable"},
+        headers={"Host": TENANT_HOST},
+    )
+    disposable = resp.get_json()
+
+    resp = api.get("/api/v1/auth/tokens", headers=auth)
+    assert resp.status_code == 200
+    names = [t["name"] for t in resp.get_json()["tokens"]]
+    assert "disposable" in names
+
+    resp = api.delete(f"/api/v1/auth/tokens/{disposable['id']}", headers=auth)
+    assert resp.status_code == 200
+
+    # The revoked token no longer authenticates.
+    resp = api.get(
+        "/api/v1/items",
+        headers={"Host": TENANT_HOST, "Authorization": f"Bearer {disposable['token']}"},
+    )
+    assert resp.status_code == 401
+    assert resp.get_json()["error"]["code"] == "token_revoked"
+
+
+# --- Items: CRUD + key checkout lifecycle ---------------------------------------
+
+def test_key_full_lifecycle(api, auth):
+    # Create
+    resp = api.post("/api/v1/items", json={
+        "type": "Key", "label": "Front Door — 123 Main", "total_copies": 5,
+        "key_hook_number": "H12", "keycode": "54321",
+    }, headers=auth)
+    assert resp.status_code == 201, resp.get_json()
+    key = resp.get_json()
+    assert key["custom_id"].startswith("K")
+    assert key["status"] == "available"
+
+    # Lookup by custom_id
+    resp = api.get(f"/api/v1/items/{key['custom_id']}", headers=auth)
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == key["id"]
+
+    # Patch
+    resp = api.patch(f"/api/v1/items/{key['id']}", json={"location": "Key cabinet A"}, headers=auth)
+    assert resp.status_code == 200
+    assert resp.get_json()["location"] == "Key cabinet A"
+
+    # Checkout 2 copies
+    resp = api.post(f"/api/v1/items/{key['id']}/checkout", json={
+        "copies": 2, "checked_out_to": "Jane Contractor", "purpose": "Showing",
+        "expected_return_date": "2026-07-20",
+    }, headers=auth)
+    assert resp.status_code == 201, resp.get_json()
+    body = resp.get_json()
+    assert body["item"]["copies_checked_out"] == 2
+    assert body["item"]["status"] == "checked_out"
+    checkout_id = body["checkout"]["id"]
+
+    # Can't check out more than available
+    resp = api.post(f"/api/v1/items/{key['id']}/checkout", json={"copies": 99}, headers=auth)
+    assert resp.status_code == 409
+    assert resp.get_json()["error"]["code"] == "no_copies_available"
+
+    # Checkouts listing shows it as active
+    resp = api.get("/api/v1/checkouts?active=true", headers=auth)
+    ids = [c["id"] for c in resp.get_json()["checkouts"]]
+    assert checkout_id in ids
+
+    # Check the specific checkout back in
+    resp = api.post(f"/api/v1/items/{key['id']}/checkin", json={"checkout_id": checkout_id}, headers=auth)
+    assert resp.status_code == 200
+    item = resp.get_json()["item"]
+    assert item["copies_checked_out"] == 0
+    assert item["status"] == "available"
+
+    # Deleting is admin-only and works when the key is available
+    resp = api.delete(f"/api/v1/items/{key['id']}", headers=auth)
+    assert resp.status_code == 200
+    resp = api.get(f"/api/v1/items/{key['id']}", headers=auth)
+    assert resp.status_code == 404
+
+
+def test_lockbox_requires_code_and_rotates(api, auth):
+    resp = api.post("/api/v1/items", json={
+        "type": "Lockbox", "label": "LB Front", "code_current": "1111",
+    }, headers=auth)
+    assert resp.status_code == 201
+    lb = resp.get_json()
+
+    # No code -> 400
+    resp = api.post(f"/api/v1/items/{lb['id']}/checkout", json={}, headers=auth)
+    assert resp.status_code == 400
+
+    # With code -> rotates
+    resp = api.post(f"/api/v1/items/{lb['id']}/checkout", json={"code": "2222"}, headers=auth)
+    assert resp.status_code == 200
+    item = resp.get_json()["item"]
+    assert item["code_previous"] == "1111"
+    assert item["code_current"] == "2222"
+    assert item["status"] == "checked_out"
+
+    resp = api.post(f"/api/v1/items/{lb['id']}/checkin", json={"code": "3333"}, headers=auth)
+    assert resp.status_code == 200
+    item = resp.get_json()["item"]
+    assert item["status"] == "available"
+    assert item["code_current"] == "3333"
+
+
+def test_sign_checkout_and_assign(api, auth):
+    resp = api.post("/api/v1/items", json={
+        "type": "Sign", "label": "For Sale — Colonial", "sign_subtype": "Piece", "piece_type": "Sign",
+    }, headers=auth)
+    assert resp.status_code == 201
+    sign = resp.get_json()
+    assert sign["custom_id"].startswith("S")
+
+    resp = api.post(f"/api/v1/items/{sign['id']}/assign", json={
+        "assigned_to": "Agent Bob", "assignment_type": "tenant",
+    }, headers=auth)
+    assert resp.status_code == 200
+    assert resp.get_json()["item"]["status"] == "assigned"
+
+    resp = api.post(f"/api/v1/items/{sign['id']}/checkin", json={}, headers=auth)
+    assert resp.status_code == 200
+    assert resp.get_json()["item"]["status"] == "available"
+
+
+def test_item_type_validation(api, auth):
+    resp = api.post("/api/v1/items", json={"type": "Spaceship", "label": "X"}, headers=auth)
+    assert resp.status_code == 400
+
+    # Key-only field rejected on a lockbox
+    resp = api.post("/api/v1/items", json={
+        "type": "Lockbox", "label": "LB2", "keycode": "12345",
+    }, headers=auth)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "unknown_fields"
+
+
+def test_items_pagination_and_filters(api, auth):
+    for i in range(3):
+        api.post("/api/v1/items", json={"type": "Key", "label": f"PageKey {i}", "total_copies": 1}, headers=auth)
+
+    resp = api.get("/api/v1/items?type=Key&per_page=2&page=1", headers=auth)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["items"]) <= 2
+    assert body["pagination"]["per_page"] == 2
+    assert body["pagination"]["total"] >= 3
+
+    resp = api.get("/api/v1/items?q=PageKey", headers=auth)
+    assert resp.get_json()["pagination"]["total"] == 3
+
+
+# --- Properties, contacts, smart locks -------------------------------------------
+
+def test_property_and_unit_crud(api, auth):
+    resp = api.post("/api/v1/properties", json={
+        "name": "Maple Apartments", "type": "multi_family",
+        "address_line1": "12 Maple St", "city": "Springfield", "state": "IL",
+    }, headers=auth)
+    assert resp.status_code == 201, resp.get_json()
+    prop = resp.get_json()
+
+    resp = api.post(f"/api/v1/properties/{prop['id']}/units", json={
+        "label": "Unit 2B", "bedrooms": 2, "bathrooms": 1.5,
+    }, headers=auth)
+    assert resp.status_code == 201
+    unit = resp.get_json()
+
+    resp = api.get(f"/api/v1/properties/{prop['id']}", headers=auth)
+    body = resp.get_json()
+    assert body["item_count"] == 0
+    assert [u["label"] for u in body["units"]] == ["Unit 2B"]
+
+    resp = api.patch(f"/api/v1/units/{unit['id']}", json={"floor": "2"}, headers=auth)
+    assert resp.get_json()["floor"] == "2"
+
+    # Assign a key to the property, then deletion is blocked
+    resp = api.post("/api/v1/items", json={"type": "Key", "label": "Maple key", "total_copies": 2}, headers=auth)
+    key = resp.get_json()
+    resp = api.post(f"/api/v1/items/{key['id']}/assign", json={
+        "assignment_type": "property", "property_id": prop["id"], "copies": 1,
+    }, headers=auth)
+    assert resp.status_code == 201, resp.get_json()
+    assert resp.get_json()["item"]["assigned_to"] == "Maple Apartments"
+
+    resp = api.delete(f"/api/v1/properties/{prop['id']}", headers=auth)
+    assert resp.status_code == 409
+
+
+def test_contact_crud_and_checkout_link(api, auth):
+    resp = api.post("/api/v1/contacts", json={
+        "name": "Carol Cleaner", "contact_type": "contractor", "email": "carol@clean.test",
+    }, headers=auth)
+    assert resp.status_code == 201
+    contact = resp.get_json()
+
+    resp = api.post("/api/v1/items", json={"type": "Key", "label": "Cleaner key", "total_copies": 3}, headers=auth)
+    key = resp.get_json()
+    resp = api.post(f"/api/v1/items/{key['id']}/checkout", json={
+        "copies": 1, "contact_id": contact["id"],
+    }, headers=auth)
+    assert resp.status_code == 201
+
+    resp = api.get(f"/api/v1/contacts/{contact['id']}", headers=auth)
+    assert len(resp.get_json()["active_checkouts"]) == 1
+
+    # Deleting a contact with active checkouts is blocked
+    resp = api.delete(f"/api/v1/contacts/{contact['id']}", headers=auth)
+    assert resp.status_code == 409
+
+
+def test_smart_lock_crud(api, auth):
+    resp = api.post("/api/v1/smart-locks", json={
+        "label": "Front Door Encode", "provider": "Schlage", "code": "080808",
+    }, headers=auth)
+    assert resp.status_code == 201
+    lock = resp.get_json()
+
+    resp = api.patch(f"/api/v1/smart-locks/{lock['id']}", json={"backup_code": "424242"}, headers=auth)
+    assert resp.get_json()["backup_code"] == "424242"
+
+    resp = api.delete(f"/api/v1/smart-locks/{lock['id']}", headers=auth)
+    assert resp.status_code == 200
+
+
+# --- Admin --------------------------------------------------------------------
+
+def test_user_management(api, auth):
+    resp = api.post("/api/v1/users", json={
+        "name": "API Staffer", "email": "staffer@acme.test", "pin": "13579", "role": "staff",
+    }, headers=auth)
+    assert resp.status_code == 201, resp.get_json()
+    user = resp.get_json()
+
+    # Non-admin token can't manage users
+    resp = api.post("/api/v1/auth/tokens", json={"email": "staffer@acme.test", "pin": "13579"},
+                    headers={"Host": TENANT_HOST})
+    staff_token = resp.get_json()["token"]
+    staff_auth = {"Host": TENANT_HOST, "Authorization": f"Bearer {staff_token}"}
+    resp = api.get("/api/v1/users", headers=staff_auth)
+    assert resp.status_code == 403
+    # ...but can read inventory
+    resp = api.get("/api/v1/items", headers=staff_auth)
+    assert resp.status_code == 200
+
+    resp = api.patch(f"/api/v1/users/{user['id']}", json={"is_active": False}, headers=auth)
+    assert resp.get_json()["is_active"] is False
+
+    # Deactivated user's token stops working
+    resp = api.get("/api/v1/items", headers=staff_auth)
+    assert resp.status_code == 401
+
+    resp = api.delete(f"/api/v1/users/{user['id']}", headers=auth)
+    assert resp.status_code == 200
+
+
+def test_settings_roundtrip(api, auth):
+    resp = api.get("/api/v1/settings", headers=auth)
+    assert resp.status_code == 200
+
+    resp = api.patch("/api/v1/settings", json={
+        "low_keys_threshold": 6, "notify_on_overdue": False,
+    }, headers=auth)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["low_keys_threshold"] == 6
+    assert body["notify_on_overdue"] is False
+
+    resp = api.patch("/api/v1/settings", json={"bogus_setting": 1}, headers=auth)
+    assert resp.status_code == 400
+
+
+def test_activity_logs_and_stats(api, auth):
+    resp = api.get("/api/v1/activity-logs", headers=auth)
+    assert resp.status_code == 200
+    assert resp.get_json()["pagination"]["total"] > 0
+
+    resp = api.get("/api/v1/stats", headers=auth)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "Key" in body["items"]
+    assert "active_checkouts" in body
+
+
+def test_accounts_requires_app_admin(api, auth, app):
+    # Tenant admin token -> 403
+    resp = api.get("/api/v1/accounts",
+                   headers={"Host": ROOT_HOST, "Authorization": auth["Authorization"]})
+    assert resp.status_code == 403
+
+    # App admin token on root domain -> 200
+    resp = api.post("/api/v1/auth/tokens", json={"email": "root@kbm.test", "pin": "8888"},
+                    headers={"Host": ROOT_HOST})
+    assert resp.status_code == 201, resp.get_json()
+    root_token = resp.get_json()["token"]
+    resp = api.get("/api/v1/accounts",
+                   headers={"Host": ROOT_HOST, "Authorization": f"Bearer {root_token}"})
+    assert resp.status_code == 200
+    subdomains = [a["subdomain"] for a in resp.get_json()["accounts"]]
+    assert "acme" in subdomains
+
+    # App admin token also works on tenant subdomains
+    resp = api.get("/api/v1/items",
+                   headers={"Host": TENANT_HOST, "Authorization": f"Bearer {root_token}"})
+    assert resp.status_code == 200

--- a/utilities/master_database.py
+++ b/utilities/master_database.py
@@ -141,6 +141,71 @@ class MasterUser(master_db.Model, UserMixin):
     )
 
 
+class ApiToken(master_db.Model):
+    """
+    Bearer token for the REST API (/api/v1).
+
+    The raw token is only shown once at creation. We store a SHA-256 hash —
+    tokens are 256-bit random secrets, so a fast hash is fine (no need for a
+    slow KDF like the PIN hashes). token_prefix is the short public part used
+    for indexed lookup and for identifying tokens in list views.
+
+    Token format: kbm_<prefix>_<secret>
+    """
+    __tablename__ = "api_tokens"
+
+    id = master_db.Column(master_db.Integer, primary_key=True)
+    # NULL account_id = app_admin token (not bound to one tenant)
+    account_id = master_db.Column(master_db.Integer, master_db.ForeignKey("accounts.id"), nullable=True, index=True)
+    user_id = master_db.Column(master_db.Integer, master_db.ForeignKey("master_users.id"), nullable=False, index=True)
+
+    name = master_db.Column(master_db.String(120), nullable=False, default="API Token")
+    token_prefix = master_db.Column(master_db.String(16), nullable=False, unique=True, index=True)
+    token_hash = master_db.Column(master_db.String(64), nullable=False)
+
+    created_at = master_db.Column(master_db.DateTime, nullable=False, default=utc_now)
+    expires_at = master_db.Column(master_db.DateTime, nullable=True)
+    last_used_at = master_db.Column(master_db.DateTime, nullable=True)
+    revoked_at = master_db.Column(master_db.DateTime, nullable=True)
+
+    user = master_db.relationship("MasterUser", foreign_keys=[user_id])
+
+    TOKEN_ENV_PREFIX = "kbm"
+
+    @staticmethod
+    def generate() -> tuple[str, str, str]:
+        """Return (raw_token, prefix, sha256_hash). Raw token is shown once."""
+        import hashlib
+        prefix = secrets.token_hex(4)  # 8 chars, public identifier
+        secret = secrets.token_urlsafe(32)
+        raw = f"{ApiToken.TOKEN_ENV_PREFIX}_{prefix}_{secret}"
+        return raw, prefix, hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def hash_raw(raw: str) -> str:
+        import hashlib
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def is_valid(self) -> bool:
+        if self.revoked_at is not None:
+            return False
+        if self.expires_at is not None and self.expires_at < utc_now():
+            return False
+        return True
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "token_prefix": self.token_prefix,
+            "user_id": self.user_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "last_used_at": self.last_used_at.isoformat() if self.last_used_at else None,
+            "revoked": self.revoked_at is not None,
+        }
+
+
 class Invitation(master_db.Model):
     """
     Invitation system for adding users to accounts.


### PR DESCRIPTION
## Summary

Adds **REST API v1** at `/api/v1` (app version 2.2.0) plus full documentation for external integrations.

### API
- **Bearer-token auth**: `POST /api/v1/auth/tokens` exchanges email + PIN for a hashed, revocable token (new `api_tokens` table in the master DB, created idempotently on boot — no migration step). Tokens inherit the user's role; app-admin tokens are cross-tenant. Rate-limited creation, optional expiry, list/revoke endpoints.
- **Full resource coverage**: items (lockboxes/keys/signs) CRUD + `checkout`/`checkin`/`assign` actions that mirror the web flows exactly per type (key copy counting + ItemCheckout records + email notifications, lockbox code rotation, sign rules), checkout history (incl. `overdue=true` filter), properties + units, contacts, smart locks, audits (read), users, tenant settings, activity logs, `/stats` summary, and `/accounts` for app admins.
- **Consistent JSON errors** (`{"error": {"code", "message"}}`) for every `/api/` path; CSRF-exempt blueprint; pagination on all list endpoints.
- Every API write produces the same activity-log entries as the web UI.

### Documentation
- `API_DOCUMENTATION.md` — integration guide (auth walkthrough, conventions, per-resource examples in curl/Python/JS/PowerShell, recipes).
- Live interactive reference at `/api/v1/docs` + OpenAPI 3.0 spec at `/api/v1/openapi.json`.
- New "API & Integrations" Help Center topic (`/help/api`).

## Testing
- New `tests/test_api.py`: **20/20 passing** — token lifecycle, tenant isolation, key checkout/checkin lifecycle, lockbox code rotation, role gating, pagination, conflict handling.
- Full suite 73/75; the 2 failures are pre-existing local-env issues (missing `qrcode` package locally) that also fail on a clean checkout of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
