### PR TITLE
Add API Keys management UI under Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to KBM (Keybox Manager) are documented here.
 Versioning: MAJOR.MINOR.PATCH. The running version is shown in the app
 sidebar and defined as `APP_VERSION` in `config.py`.
 
+## [2.3.0] — 2026-07-13
+
+### Added
+- **API Keys management page** (`/settings/api-keys`, linked from the
+  sidebar): create keys with a name and optional expiry (30/90/365 days or
+  never), copy the key from a show-once reveal box, and revoke keys with
+  one click. Every logged-in user manages their own keys; admins see all
+  keys in the account with owner and last-used time. Key creation and
+  revocation are recorded in the tenant activity log.
+- Sidebar links: "API Keys" in the Administration section (admins) and in
+  the sidebar footer (all users). The in-app "? Help" button on the page
+  opens the API help topic, updated to describe the new UI.
+- Tests for the page (`tests/test_api_keys_ui.py`): show-once behavior,
+  UI-minted keys authenticating against the API, revocation, and
+  cross-user permission checks.
+
 ## [2.2.0] — 2026-07-13
 
 Full REST API release.

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ if env_file:
     load_dotenv(env_file)
 
 # Application version — keep in sync with CHANGELOG.md.
-APP_VERSION = "2.2.0"
+APP_VERSION = "2.3.0"
 
 
 class Config:

--- a/helpcenter/views.py
+++ b/helpcenter/views.py
@@ -75,6 +75,9 @@ _ENDPOINT_PREFIX_MAP = [
     ("auth.edit_user", "users-roles"),
     ("auth.activity_logs", "users-roles"),
     ("auth.export_activity_logs", "users-roles"),
+    ("settings.api_key", "api"),
+    ("settings.create_api_key", "api"),
+    ("settings.revoke_api_key", "api"),
 ]
 
 _BLUEPRINT_MAP = {

--- a/settings/views.py
+++ b/settings/views.py
@@ -1,14 +1,19 @@
-"""Per-tenant settings page.
+"""Per-tenant settings pages.
 
-Tenant-scoped (requires a subdomain) and admin-only. Stores config in the
-tenant DB via TenantSettings.
+Tenant-scoped (requires a subdomain). The main settings page is admin-only;
+the API Keys page is open to every logged-in user (each user manages their
+own keys, admins manage the whole account's).
 """
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+from datetime import timedelta
+
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, session
 from flask_login import login_required, current_user
 
 from middleware.tenant_middleware import tenant_required
-from utilities.database import get_tenant_settings
+from utilities.database import get_tenant_settings, log_activity, utc_now
+from utilities.master_database import master_db, ApiToken, MasterUser
 from utilities.tenant_helpers import tenant_commit
+from utilities.tenant_manager import tenant_manager
 
 
 settings_bp = Blueprint(
@@ -77,3 +82,123 @@ def save_settings():
     tenant_commit()
     flash("Settings saved.", "success")
     return redirect(url_for("settings.settings_page"))
+
+
+# ============================================================
+# API Keys
+# ============================================================
+
+MAX_TOKENS_PER_USER = 25  # matches api/routes_tokens.py
+
+_EXPIRY_CHOICES = {"never": None, "30": 30, "90": 90, "365": 365}
+
+
+def _is_admin() -> bool:
+    return (getattr(current_user, "role", "") or "").lower() in {"admin", "owner", "app_admin"}
+
+
+def _visible_tokens_query():
+    """Own tokens for regular users; the whole account's for admins."""
+    if _is_admin():
+        tenant = tenant_manager.get_current_tenant()
+        return ApiToken.query.filter(ApiToken.account_id == tenant.id)
+    return ApiToken.query.filter(ApiToken.user_id == current_user.id)
+
+
+@settings_bp.get("/api-keys")
+@login_required
+@tenant_required
+def api_keys():
+    tokens = _visible_tokens_query().order_by(ApiToken.created_at.desc()).all()
+
+    # Map user ids -> names so admins can see who owns each key.
+    user_ids = {t.user_id for t in tokens}
+    users = {}
+    if user_ids:
+        for u in MasterUser.query.filter(MasterUser.id.in_(user_ids)).all():
+            users[u.id] = u.name
+
+    # A token created on the previous request is shown exactly once (PRG:
+    # the POST stashes it in the session, this GET pops it).
+    new_token = session.pop("new_api_token", None)
+
+    now = utc_now()
+    return render_template(
+        "settings_api_keys.html",
+        tokens=tokens,
+        token_users=users,
+        new_token=new_token,
+        now=now,
+        is_admin=_is_admin(),
+    )
+
+
+@settings_bp.post("/api-keys")
+@login_required
+@tenant_required
+def create_api_key():
+    name = (request.form.get("name") or "").strip()[:120] or "API Token"
+    expiry_choice = (request.form.get("expires") or "never").strip()
+    expires_in_days = _EXPIRY_CHOICES.get(expiry_choice, None)
+
+    active_count = ApiToken.query.filter_by(user_id=current_user.id, revoked_at=None).count()
+    if active_count >= MAX_TOKENS_PER_USER:
+        flash(f"You already have {active_count} active API keys. Revoke one before creating another.", "error")
+        return redirect(url_for("settings.api_keys"))
+
+    raw, prefix, token_hash = ApiToken.generate()
+    token = ApiToken(
+        account_id=current_user.account_id,
+        user_id=current_user.id,
+        name=name,
+        token_prefix=prefix,
+        token_hash=token_hash,
+        expires_at=(utc_now() + timedelta(days=expires_in_days)) if expires_in_days else None,
+    )
+    master_db.session.add(token)
+    master_db.session.commit()
+
+    log_activity(
+        "api_token_created",
+        user=current_user,
+        target_type="ApiToken",
+        target_id=token.id,
+        summary=f"Created API key \"{name}\" ({prefix}…)",
+        meta={"expires_in_days": expires_in_days},
+        commit=True,
+    )
+
+    session["new_api_token"] = raw
+    flash("API key created. Copy it now — it won't be shown again.", "success")
+    return redirect(url_for("settings.api_keys"))
+
+
+@settings_bp.post("/api-keys/<int:token_id>/revoke")
+@login_required
+@tenant_required
+def revoke_api_key(token_id: int):
+    token = master_db.session.get(ApiToken, token_id)
+
+    allowed = token is not None and (
+        token.user_id == current_user.id
+        or (_is_admin() and token.account_id == tenant_manager.get_current_tenant().id)
+    )
+    if not allowed:
+        abort(404)
+
+    if token.revoked_at is None:
+        token.revoked_at = utc_now()
+        master_db.session.commit()
+        log_activity(
+            "api_token_revoked",
+            user=current_user,
+            target_type="ApiToken",
+            target_id=token.id,
+            summary=f"Revoked API key \"{token.name}\" ({token.token_prefix}…)",
+            commit=True,
+        )
+        flash(f"API key \"{token.name}\" revoked.", "success")
+    else:
+        flash("That API key was already revoked.", "info")
+
+    return redirect(url_for("settings.api_keys"))

--- a/templates/base.html
+++ b/templates/base.html
@@ -1261,7 +1261,10 @@
               <a href="{{ url_for('auth.activity_logs') }}" class="{% if request.endpoint == 'auth.activity_logs' %}active{% endif %}">
                 <span class="nav-icon">📋</span> Activity Logs
               </a>
-              <a href="{{ url_for('settings.settings_page') }}" class="{% if request.endpoint and request.endpoint.startswith('settings.') %}active{% endif %}">
+              <a href="{{ url_for('settings.api_keys') }}" class="{% if request.endpoint and request.endpoint.startswith('settings.api_key') %}active{% endif %}">
+                <span class="nav-icon">🔑</span> API Keys
+              </a>
+              <a href="{{ url_for('settings.settings_page') }}" class="{% if request.endpoint in ('settings.settings_page', 'settings.save_settings') %}active{% endif %}">
                 <span class="nav-icon">⚙️</span> Settings
               </a>
             </div>
@@ -1277,6 +1280,9 @@
             <div class="toolbar toolbar-column">
               <a class="btn ghost" href="{{ url_for('help.index') }}">❓ Help Center</a>
               <a class="btn ghost" href="{{ url_for('auth.profile') }}">Profile</a>
+              {% if not is_root_domain %}
+              <a class="btn ghost" href="{{ url_for('settings.api_keys') }}">🔑 API Keys</a>
+              {% endif %}
               <button class="btn ghost" type="button" data-theme-toggle>Toggle Dark Mode</button>
               <a class="btn danger" href="{{ url_for('auth.logout') }}">Logout</a>
             </div>

--- a/templates/help/api.html
+++ b/templates/help/api.html
@@ -16,15 +16,18 @@ manage properties and contacts) can be done through the API.</p>
       project repository: walkthroughs and copy-paste examples.</li>
 </ul>
 
-<h2>Getting an API token</h2>
+<h2>Getting an API key</h2>
+<p>The easiest way is in the app: open <strong>API Keys</strong> (in the sidebar,
+or under Administration for admins), give the key a name, pick an expiry, and
+click <strong>Create API Key</strong>.</p>
 <ol>
-  <li>Send a <code>POST</code> request to <code>/api/v1/auth/tokens</code> on your
-      company's address with your login <strong>email</strong> and <strong>PIN</strong>.</li>
-  <li>Copy the returned <code>token</code> — it is shown <strong>only once</strong>.
+  <li>Copy the key right away — it is shown <strong>only once</strong>.
       Store it somewhere safe, like a password manager.</li>
   <li>Send it with every request as a header:
       <code>Authorization: Bearer kbm_…</code></li>
 </ol>
+<p>Programmatic alternative: <code>POST /api/v1/auth/tokens</code> with your login
+<strong>email</strong> and <strong>PIN</strong> returns a new key without using the UI.</p>
 
 <div class="help-callout">
   <strong>Permissions follow your role.</strong> A token can do exactly what the
@@ -32,14 +35,15 @@ manage properties and contacts) can be done through the API.</p>
   admin or owner token. Deactivating a user immediately disables their tokens.
 </div>
 
-<h2>Managing tokens</h2>
+<h2>Managing keys</h2>
 <ul>
-  <li><strong>List</strong> — <code>GET /api/v1/auth/tokens</code> (admins see every
-      token in the account, including who created it and when it was last used).</li>
-  <li><strong>Revoke</strong> — <code>DELETE /api/v1/auth/tokens/&lt;id&gt;</code>.
-      Takes effect immediately.</li>
-  <li><strong>Expiry</strong> — pass <code>expires_in_days</code> when creating a token
-      to make it expire automatically.</li>
+  <li><strong>In the app</strong> — the API Keys page lists your keys (admins see
+      every key in the account with its owner and last-used time) and has a
+      Revoke button for each. Revoking takes effect immediately.</li>
+  <li><strong>Via the API</strong> — <code>GET /api/v1/auth/tokens</code> to list,
+      <code>DELETE /api/v1/auth/tokens/&lt;id&gt;</code> to revoke.</li>
+  <li><strong>Expiry</strong> — choose an expiry when creating a key (or pass
+      <code>expires_in_days</code> via the API) to make it expire automatically.</li>
 </ul>
 
 <h2>Good to know</h2>

--- a/templates/settings_api_keys.html
+++ b/templates/settings_api_keys.html
@@ -1,0 +1,185 @@
+{% extends "base.html" %}
+{% block title %}API Keys - KBM{% endblock %}
+
+{% block head %}
+<style>
+  .settings-section + .settings-section { margin-top: 18px; }
+  .field-help {
+    font-size: 13px;
+    color: var(--color-muted);
+    margin-top: 4px;
+  }
+  .create-key-form {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+  }
+  .create-key-form .form-field { margin: 0; }
+  .create-key-form input[type="text"] { min-width: 260px; }
+  .create-key-form select { min-width: 140px; }
+
+  .new-token-box {
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent-soft);
+    border-radius: 10px;
+    padding: 14px 16px;
+    margin-bottom: 18px;
+  }
+  .new-token-box .token-value {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-top: 8px;
+  }
+  .new-token-box code {
+    flex: 1;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px;
+    background: rgba(148, 163, 184, 0.12);
+    border-radius: 6px;
+    padding: 8px 10px;
+    word-break: break-all;
+    user-select: all;
+  }
+
+  table.keys-table { width: 100%; border-collapse: collapse; }
+  .keys-table th, .keys-table td {
+    text-align: left;
+    padding: 9px 10px;
+    border-bottom: 1px solid var(--color-border);
+    font-size: 13.5px;
+    vertical-align: middle;
+  }
+  .keys-table th {
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+  }
+  .keys-table .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12.5px;
+  }
+  .key-status {
+    display: inline-block;
+    padding: 2px 9px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .key-status.active { background: rgba(74, 222, 128, 0.14); color: #4ade80; }
+  .key-status.revoked { background: rgba(248, 113, 113, 0.14); color: #f87171; }
+  .key-status.expired { background: rgba(148, 163, 184, 0.18); color: var(--color-muted); }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1>🔑 API Keys</h1>
+  <p class="muted">
+    Connect other apps to KBM with the REST API. Keys act with your
+    permissions — treat them like passwords.
+    <a href="{{ url_for('api.docs') }}" target="_blank">API reference</a> ·
+    <a href="{{ url_for('help.topic', slug='api') }}">Help</a>
+  </p>
+</div>
+
+{% if new_token %}
+<div class="new-token-box">
+  <strong>Your new API key</strong> — copy it now, it will not be shown again.
+  <div class="token-value">
+    <code id="new-token">{{ new_token }}</code>
+    <button type="button" class="btn primary" id="copy-token-btn"
+            onclick="navigator.clipboard.writeText(document.getElementById('new-token').textContent).then(() => { this.textContent = 'Copied ✓'; })">
+      Copy
+    </button>
+  </div>
+  <p class="field-help" style="margin-top: 8px;">
+    Use it as a header on every request:
+    <span class="mono">Authorization: Bearer {{ new_token[:16] }}…</span>
+  </p>
+</div>
+{% endif %}
+
+<div class="card settings-section">
+  <h2>Create a key</h2>
+  <div class="divider"></div>
+  <form method="post" action="{{ url_for('settings.create_api_key') }}" class="create-key-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <div class="form-field">
+      <label for="key-name">Name</label>
+      <input type="text" id="key-name" name="name" maxlength="120"
+             placeholder="e.g. zapier, reporting-script" required>
+    </div>
+    <div class="form-field">
+      <label for="key-expires">Expires</label>
+      <select id="key-expires" name="expires">
+        <option value="never">Never</option>
+        <option value="30">In 30 days</option>
+        <option value="90">In 90 days</option>
+        <option value="365">In 1 year</option>
+      </select>
+    </div>
+    <button type="submit" class="btn primary">Create API Key</button>
+  </form>
+  <p class="field-help" style="margin-top: 10px;">
+    The key is shown once at creation. Give each integration its own key so
+    you can revoke them independently.
+  </p>
+</div>
+
+<div class="card settings-section">
+  <h2>{% if is_admin %}All keys in this account{% else %}Your keys{% endif %}</h2>
+  <div class="divider"></div>
+
+  {% if tokens %}
+  <table class="keys-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Key</th>
+        {% if is_admin %}<th>Owner</th>{% endif %}
+        <th>Created</th>
+        <th>Last used</th>
+        <th>Expires</th>
+        <th>Status</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for t in tokens %}
+      {% set expired = t.expires_at and t.expires_at < now %}
+      <tr>
+        <td><strong>{{ t.name }}</strong></td>
+        <td class="mono">kbm_{{ t.token_prefix }}_…</td>
+        {% if is_admin %}<td>{{ token_users.get(t.user_id, 'Unknown') }}</td>{% endif %}
+        <td>{{ t.created_at.strftime('%Y-%m-%d') if t.created_at else '—' }}</td>
+        <td>{{ t.last_used_at.strftime('%Y-%m-%d %H:%M') if t.last_used_at else 'never' }}</td>
+        <td>{{ t.expires_at.strftime('%Y-%m-%d') if t.expires_at else 'never' }}</td>
+        <td>
+          {% if t.revoked_at %}<span class="key-status revoked">revoked</span>
+          {% elif expired %}<span class="key-status expired">expired</span>
+          {% else %}<span class="key-status active">active</span>{% endif %}
+        </td>
+        <td>
+          {% if not t.revoked_at and not expired %}
+          <form method="post" action="{{ url_for('settings.revoke_api_key', token_id=t.id) }}"
+                onsubmit="return confirm('Revoke API key “{{ t.name }}”? Anything using it will stop working immediately.');"
+                style="display:inline;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <button type="submit" class="btn danger">Revoke</button>
+          </form>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No API keys yet. Create one above to get started.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_api_keys_ui.py
+++ b/tests/test_api_keys_ui.py
@@ -1,0 +1,106 @@
+"""Tests for the API Keys management page under Settings."""
+import re
+
+TENANT = {"Host": "acme.localhost"}
+
+
+def _create_key(client, name="ui-test-key", expires="never"):
+    return client.post("/settings/api-keys", data={"name": name, "expires": expires},
+                       headers=TENANT, follow_redirects=True)
+
+
+def test_page_requires_login(client):
+    resp = client.get("/settings/api-keys", headers=TENANT)
+    assert resp.status_code == 302  # bounced to login
+
+
+def test_page_renders(tenant_client):
+    resp = tenant_client.get("/settings/api-keys", headers=TENANT)
+    assert resp.status_code == 200
+    assert b"API Keys" in resp.data
+    assert b"Create API Key" in resp.data
+
+
+def test_create_shows_token_once(tenant_client):
+    resp = _create_key(tenant_client, name="show-once")
+    assert resp.status_code == 200
+    # Raw token appears exactly once, right after creation...
+    match = re.search(rb"kbm_[0-9a-f]{8}_[A-Za-z0-9_\-]+", resp.data)
+    assert match, "raw token should be shown after creation"
+    raw = match.group(0).decode()
+
+    # ...and is gone on the next page load (only the masked prefix remains).
+    resp2 = tenant_client.get("/settings/api-keys", headers=TENANT)
+    assert raw.encode() not in resp2.data
+    assert b"show-once" in resp2.data
+    assert "kbm_{}_…".format(raw.split("_")[1]).encode() in resp2.data
+
+    # The token actually works against the API.
+    resp3 = tenant_client.get("/api/v1/me",
+                              headers={**TENANT, "Authorization": f"Bearer {raw}"})
+    assert resp3.status_code == 200
+
+
+def test_create_with_expiry(tenant_client):
+    resp = _create_key(tenant_client, name="expiring", expires="30")
+    assert resp.status_code == 200
+    resp = tenant_client.get("/settings/api-keys", headers=TENANT)
+    assert b"expiring" in resp.data
+
+
+def test_revoke_kills_token(app, tenant_client):
+    resp = _create_key(tenant_client, name="to-revoke")
+    raw = re.search(rb"kbm_[0-9a-f]{8}_[A-Za-z0-9_\-]+", resp.data).group(0).decode()
+
+    from utilities.master_database import ApiToken
+    with app.app_context():
+        token = ApiToken.query.filter_by(token_prefix=raw.split("_")[1]).first()
+        assert token is not None
+        token_id = token.id
+
+    resp = tenant_client.post(f"/settings/api-keys/{token_id}/revoke",
+                              headers=TENANT, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"revoked" in resp.data.lower()
+
+    # Token no longer authenticates.
+    resp = tenant_client.get("/api/v1/me",
+                             headers={**TENANT, "Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 401
+
+
+def test_cannot_revoke_other_users_token_as_non_admin(app, tenant_client):
+    """A regular user must not be able to revoke the admin's key."""
+    from utilities.master_database import master_db, ApiToken, MasterUser, Account
+
+    with app.app_context():
+        account = Account.query.filter_by(subdomain="acme").first()
+        regular = MasterUser.query.filter_by(email="regular@acme.test").first()
+        if regular is None:
+            regular = MasterUser(account_id=account.id, name="Regular User",
+                                 email="regular@acme.test", role="user", is_active=True)
+            regular.set_pin("2468")
+            master_db.session.add(regular)
+            master_db.session.commit()
+
+    # Admin creates a key
+    resp = _create_key(tenant_client, name="admins-key")
+    raw = re.search(rb"kbm_[0-9a-f]{8}_[A-Za-z0-9_\-]+", resp.data).group(0).decode()
+    with app.app_context():
+        admin_token = ApiToken.query.filter_by(token_prefix=raw.split("_")[1]).first()
+        admin_token_id = admin_token.id
+
+    # Regular user logs in and tries to revoke it
+    c = app.test_client()
+    login = c.post("/auth/login", data={"pin": "2468"}, headers=TENANT)
+    assert login.status_code == 302
+    resp = c.post(f"/settings/api-keys/{admin_token_id}/revoke", headers=TENANT)
+    assert resp.status_code == 404
+
+    # And doesn't see it in their list
+    resp = c.get("/settings/api-keys", headers=TENANT)
+    assert b"admins-key" not in resp.data
+
+    # Admin's key still works
+    resp = c.get("/api/v1/me", headers={**TENANT, "Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Adds an **API Keys management page** at `/settings/api-keys` (version 2.3.0) so users can create and revoke API tokens without touching the API directly.

- **Create**: name + optional expiry (30/90/365 days or never). The key is revealed **once** in a copy-to-clipboard box (PRG pattern — stored in session for exactly one page load, never in a URL).
- **List**: regular users see their own keys; admins/owners see every key in the account with owner and last-used time. Status pills for active / expired / revoked.
- **Revoke**: one click with a confirm dialog; takes effect immediately. Non-admins get a 404 for keys they don't own (no existence leak).
- **Discoverability**: sidebar links in the Administration section (admins) and sidebar footer (all users); the page's "? Help" button opens the API help topic, updated to describe the UI flow.
- Creation and revocation are recorded in the tenant activity log.

## Testing
- New `tests/test_api_keys_ui.py` (6 tests): login gate, page render, show-once behavior (raw key present after create, absent on reload), UI-minted key authenticates against `/api/v1/me`, revoke invalidates it, and a non-admin can neither see nor revoke another user's key.
- Full suite 79/81 — the 2 failures are the known pre-existing local-env issues (missing `qrcode` package), unchanged from main.
- Verified visually in the browser: seeded a throwaway tenant, logged in, created a key through the UI, confirmed it worked via `curl /api/v1/me`, confirmed show-once, then removed the throwaway tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
